### PR TITLE
Rename domain to project everywhere.

### DIFF
--- a/commcare_export/cli.py
+++ b/commcare_export/cli.py
@@ -33,7 +33,7 @@ def main(argv):
     parser.add_argument('--dump-query', default=False, action='store_true')
     parser.add_argument('--commcare-hq', default='prod')
     parser.add_argument('--api-version', default=LATEST_KNOWN_VERSION)
-    parser.add_argument('--domain', required=True)
+    parser.add_argument('--project', required=True)
     parser.add_argument('--username')
     parser.add_argument('--password')
     parser.add_argument('--since')
@@ -95,7 +95,7 @@ def main_with_args(args):
 
     # Build an API client using either the URL provided, or the URL for a known alias
     api_client = CommCareHqClient(url = commcare_hq_aliases.get(args.commcare_hq, args.commcare_hq), 
-                                  domain = args.domain,
+                                  project = args.project,
                                   version = args.api_version)
 
     api_client = api_client.authenticated(username=args.username, password=args.password)

--- a/commcare_export/commcare_hq_client.py
+++ b/commcare_export/commcare_hq_client.py
@@ -18,13 +18,13 @@ LATEST_KNOWN_VERSION='0.4'
 
 class CommCareHqClient(object):
     """
-    A connection to CommCareHQ for a particular version, domain, and user.
+    A connection to CommCareHQ for a particular version, project, and user.
     """
 
-    def __init__(self, url, domain, version=LATEST_KNOWN_VERSION, session=None):
+    def __init__(self, url, project, version=LATEST_KNOWN_VERSION, session=None):
         self.version = version
         self.url = url
-        self.domain = domain
+        self.project = project
         self.__session = session
 
     @property
@@ -35,7 +35,7 @@ class CommCareHqClient(object):
 
     @property
     def api_url(self):
-        return '%s/a/%s/api/v%s' % (self.url, self.domain, self.version)
+        return '%s/a/%s/api/v%s' % (self.url, self.project, self.version)
 
     def authenticated(self, username=None, password=None):
         """
@@ -60,7 +60,7 @@ class CommCareHqClient(object):
         if response.status_code != 200:
             raise Exception('Authentication failed (%s): %s' % (response.status_code, response.text))
         
-        return CommCareHqClient(url = self.url, domain = self.domain, version = self.version, session = session)
+        return CommCareHqClient(url = self.url, project = self.project, version = self.version, session = session)
 
     def get(self, resource, params=None):
         """


### PR DESCRIPTION
This code is external to CCHQ so it uses external terminology on the command-line, and it makes sense to do so everywhere.
