### PR TITLE
Restore default travis notifications

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,3 @@ python:
 script: python setup.py test
 services:
  - postgres
-notifications:
-  email:
-    - kknowles@dimagi.com


### PR DESCRIPTION
Previously it was hardcoded to only email me since I was on a public dimagi fork. Now we can go default since I'll be pushing broken stuff only to my forks :-)
