### PR TITLE
Include examples in distributed package

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,0 @@
-include examples/*.*

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,6 @@
 import os.path
 import sys
+import glob
 import subprocess
 import setuptools 
 from setuptools.command.test import test as TestCommand
@@ -32,6 +33,7 @@ setuptools.setup(
     url = "https://github.com/dimagi/commcare-export",
     entry_points = { 'console_scripts': ['commcare-export = commcare_export.cli:entry_point'] },
     packages = ['commcare_export'],
+    data_files = [(os.path.join('share', 'commcare-export', 'examples'), glob.glob('examples/*.json') + glob.glob('examples/*.xlsx'))],
     license = 'MIT',
     install_requires = ['jsonpath_rw>=1.1',
                         'openpyxl',


### PR DESCRIPTION
FYI in order to easily reference the examples in instructions I'm making sure they ship with the package. It may still be too unpredictable a location and we just need to separately attach them to the Wiki, etc.
