### PR TITLE
standardize filters

### DIFF
--- a/commcare_export/excel_query.py
+++ b/commcare_export/excel_query.py
@@ -144,10 +144,7 @@ def compile_source(worksheet):
         if include_referenced_items:
             api_query_args.append(Literal(None)) # Pad the argument list if we have further args; keeps tests and user code more readable at the expense of this conditional
     else:
-        if data_source == 'form':
-            api_query_args.append(Literal( {'filter': {'and': [{'term': {filter_name: filter_value}} for filter_name, filter_value in filters]}}))
-        elif data_source == 'case':
-            api_query_args.append(Literal(dict(filters)))
+        api_query_args.append(Literal(dict(filters)))
 
     if include_referenced_items:
         api_query_args.append(Literal(include_referenced_items))

--- a/commcare_export/writers.py
+++ b/commcare_export/writers.py
@@ -313,4 +313,3 @@ class SqlTableWriter(TableWriter):
             self.upsert(self.table(table_name), row_dict)
 
         if logger.getEffectiveLevel() == 'DEBUG': sys.stderr.write('\n')
-        

--- a/tests/test_commcare_minilinq.py
+++ b/tests/test_commcare_minilinq.py
@@ -1,6 +1,4 @@
 import unittest
-import simplejson
-import urllib
 from itertools import *
 
 from jsonpath_rw import jsonpath
@@ -26,11 +24,11 @@ class TestCommCareMiniLinq(unittest.TestCase):
         client = MockCommCareHqClient({
             'form': [
                 (
-                    {'limit': 1000, '_search': simplejson.dumps({"filter":"test1"}, separators=(',',':'))},
+                    {'limit': 1000, 'filter': 'test1'},
                     [1, 2, 3],
                 ),
                 (
-                    {'limit': 1000, '_search': simplejson.dumps({"filter":"test2"}, separators=(',', ':'))},
+                    {'limit': 1000, 'filter': 'test2'},
                     [
                         { 'x': [{ 'y': 1 }, {'y': 2}] },
                         { 'x': [{ 'y': 3 }, {'z': 4}] },
@@ -38,13 +36,13 @@ class TestCommCareMiniLinq(unittest.TestCase):
                     ]
                 ),
                 (
-                    {'limit': 1000, '_search': simplejson.dumps({'filter':'laziness-test'}, separators=(',', ':'))},
+                    {'limit': 1000, 'filter': 'laziness-test'},
                     (i if i < 5 else die('Not lazy enough') for i in range(12))
                 ),
                 (
                     {'limit': 1000, 'cases__full': 'true'},
                     [1, 2, 3, 4, 5]
-                )
+                ),
             ],
 
             'case': [

--- a/tests/test_excel_query.py
+++ b/tests/test_excel_query.py
@@ -79,13 +79,9 @@ class TestExcelQuery(unittest.TestCase):
                   source=Apply(Reference("api_data"), 
                                Literal("form"),  
                                Literal({
-                                   'filter': {
-                                       'and': [
-                                           {'term': { 'app_id': 'foobizzle' }},
-                                           {'term': { 'type': 'intake' }}
-                                        ]
-                                   }
-                               })))),
+                                   'app_id': 'foobizzle',
+                                   'type': 'intake',
+                               })   ))),
 
             ('003_DataSourceAndEmitColumns.xlsx',
              Emit(table    = 'Forms',
@@ -109,7 +105,7 @@ class TestExcelQuery(unittest.TestCase):
                   source=Apply(Reference("api_data"), 
                                Literal("form"),
                                Literal(None),
-                               Literal(['foo', 'bar', 'bizzle']))))
+                               Literal(['foo', 'bar', 'bizzle'])))),
         ]
 
         for filename, minilinq in test_cases:


### PR DESCRIPTION
All resources support the same filtering mechanism via URL parameters.

This will allow specifying other filters for the form endpoint without relying on the `_search` backdoor.