### PR TITLE
Add type support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 python:
- - "2.6"
  - "2.7"
 # - "3.3"
 install:

--- a/commcare_export/cli.py
+++ b/commcare_export/cli.py
@@ -50,6 +50,7 @@ def main(argv):
     parser.add_argument('--verbose', default=False, action='store_true')
     parser.add_argument('--output-format', default='json', choices=['json', 'csv', 'xls', 'xlsx', 'sql', 'markdown'], help='Output format')
     parser.add_argument('--output', metavar='PATH', default='reports.zip', help='Path to output; defaults to `reports.zip`.')
+    parser.add_argument('--strict-types', default=False, action='store_true', help="When saving to a SQL database don't allow changing column types once they are created.")
 
     args = parser.parse_args(argv)
 
@@ -137,7 +138,7 @@ def main_with_args(args):
         # Writer had bizarre issues so we use a full connection instead of passing in a URL or engine
         import sqlalchemy
         engine = sqlalchemy.create_engine(args.output)
-        writer = writers.SqlTableWriter(engine.connect())
+        writer = writers.SqlTableWriter(engine.connect(), args.strict_types)
 
         if not args.since and not args.start_over and os.path.exists(args.query):
             connection = sqlalchemy.create_engine(args.output)

--- a/commcare_export/env.py
+++ b/commcare_export/env.py
@@ -222,7 +222,7 @@ class JsonPathEnv(Env):
 def str2bool(val):
     if isinstance(val, bool):
         return val
-    return val and val.lower() in {'true', 't', '1'}
+    return val and str(val).lower() in {'true', 't', '1'}
 
 @unwrap
 def str2num(val):

--- a/commcare_export/env.py
+++ b/commcare_export/env.py
@@ -1,5 +1,4 @@
 from __future__ import unicode_literals, print_function, absolute_import, division, generators, nested_scopes
-import functools
 import operator
 import six
 from itertools import chain

--- a/commcare_export/minilinq.py
+++ b/commcare_export/minilinq.py
@@ -7,6 +7,7 @@ from six.moves import map
 
 from jsonpath_rw import jsonpath
 from jsonpath_rw.parser import parse as parse_jsonpath
+from commcare_export.misc import unwrap
 
 from commcare_export.repeatable_iterator import RepeatableIterator
 
@@ -377,18 +378,16 @@ class Emit(MiniLinq):
         self.headings = headings
         self.source = source
 
+    @unwrap
     def coerce_cell_blithely(self, cell):
-        if isinstance(cell, jsonpath.DatumInContext):
-            cell = cell.value
-        
         if isinstance(cell, six.string_types):
             return cell
-        elif isinstance(cell, int):
-            return str(cell)
+        elif isinstance(cell, (int, bool)):
+            return cell
         elif isinstance(cell, datetime):
             return cell
         elif cell is None:
-            return ''
+            return None
 
         # In all other cases, coerce to a list and join with ',' for now
         return ','.join([self.coerce_cell(item) for item in list(cell)])

--- a/commcare_export/minilinq.py
+++ b/commcare_export/minilinq.py
@@ -380,17 +380,10 @@ class Emit(MiniLinq):
 
     @unwrap
     def coerce_cell_blithely(self, cell):
-        if isinstance(cell, six.string_types):
+        if isinstance(cell, list):
+            return ','.join([self.coerce_cell(item) for item in cell])
+        else:
             return cell
-        elif isinstance(cell, (int, bool)):
-            return cell
-        elif isinstance(cell, datetime):
-            return cell
-        elif cell is None:
-            return None
-
-        # In all other cases, coerce to a list and join with ',' for now
-        return ','.join([self.coerce_cell(item) for item in list(cell)])
 
     def coerce_cell(self, cell):
         try:

--- a/commcare_export/misc.py
+++ b/commcare_export/misc.py
@@ -1,7 +1,10 @@
 from __future__ import unicode_literals, print_function, absolute_import, division, generators, nested_scopes
+import functools
 import hashlib
 import io
-import json
+from jsonpath_rw import jsonpath
+from commcare_export.repeatable_iterator import RepeatableIterator
+
 
 def digest_file(path):
     with io.open(path, 'rb') as filehandle:
@@ -12,3 +15,19 @@ def digest_file(path):
                 break
             digest.update(chunk)
         return digest.hexdigest()
+
+
+def unwrap(fn):
+    @functools.wraps(fn)
+    def _inner(*args):
+        val = args[1] if len(args) == 2 else args[0]
+
+        if isinstance(val, RepeatableIterator):
+            val = list(val)[0]
+
+        if isinstance(val, jsonpath.DatumInContext):
+            val = val.value
+
+        return fn(*([val] if len(args) == 1 else [args[0], val]))
+
+    return _inner

--- a/commcare_export/misc.py
+++ b/commcare_export/misc.py
@@ -20,14 +20,22 @@ def digest_file(path):
 def unwrap(fn):
     @functools.wraps(fn)
     def _inner(*args):
+        # handle case when fn is a class method and first arg is 'self'
         val = args[1] if len(args) == 2 else args[0]
 
         if isinstance(val, RepeatableIterator):
-            val = list(val)[0]
+            val = list(val)
+
+        if isinstance(val, list):
+            if len(val) == 1:
+                val = val[0]
+            else:
+                val = map(_inner, val)
 
         if isinstance(val, jsonpath.DatumInContext):
             val = val.value
 
+        # call fn with 'self' if necessary
         return fn(*([val] if len(args) == 1 else [args[0], val]))
 
     return _inner

--- a/commcare_export/writers.py
+++ b/commcare_export/writers.py
@@ -156,7 +156,7 @@ class JValueTableWriter(TableWriter):
         # Ensures the table is iterable; probably better to create a custom JSON handler that runs in constant space
         self.tables.append(dict(name=table['name'],
                                 headings=list(table['headings']),
-                                rows=[list([to_jvalue(v) for v in row]) for row in table['rows']]))
+                                rows=[[to_jvalue(v) for v in row] for row in table['rows']]))
 
 class StreamingMarkdownTableWriter(TableWriter):
     """

--- a/commcare_export/writers.py
+++ b/commcare_export/writers.py
@@ -308,7 +308,7 @@ class SqlTableWriter(TableWriter):
         columns = get_cols()
 
         for column, val in row_dict.items():
-            if val is None:
+            if val is None and self.strict_types:
                 continue
 
             ty = self.best_type_for(val)

--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,7 @@ setuptools.setup(
         'alembic',
         'argparse',
         'jsonpath-rw>=1.2.1',
-        'openpyxl>=2.0.3',
+        'openpyxl<2.1.0',
         'python-dateutil',
         'requests',
         'simplejson',

--- a/tests/test_minilinq.py
+++ b/tests/test_minilinq.py
@@ -102,14 +102,14 @@ class TestMiniLinq(unittest.TestCase):
             pass
 
     def test_emit(self):
-        env = BuiltInEnv() | JsonPathEnv({'foo': {'baz': 3}})
+        env = BuiltInEnv() | JsonPathEnv({'foo': {'baz': 3, 'bar': True}})
         Emit(table='Foo',
              headings=[Literal('foo')],
              source=List([
-                 List([ Reference('foo.baz') ])
+                 List([ Reference('foo.baz'), Reference('foo.bar') ])
              ])).eval(env)
 
-        assert list(list(env.emitted_tables())[0]['rows']) == [['3']]
+        assert list(list(env.emitted_tables())[0]['rows']) == [[3, True]]
 
     def test_from_jvalue(self):
         assert MiniLinq.from_jvalue({"Ref": "form.log_subreport"}) == Reference("form.log_subreport")

--- a/tests/test_minilinq.py
+++ b/tests/test_minilinq.py
@@ -54,6 +54,18 @@ class TestMiniLinq(unittest.TestCase):
         assert Apply(Reference("*"), Literal(2), Literal(3)).eval(env) == 6
         assert Apply(Reference(">"), Literal(56), Literal(23.5)).eval(env) == True
         assert Apply(Reference("len"), Literal([1, 2, 3])).eval(env) == 3
+        assert Apply(Reference("bool"), Literal('a')).eval(env) == True
+        assert Apply(Reference("bool"), Literal('')).eval(env) == False
+        assert Apply(Reference("str2bool"), Literal('true')).eval(env) == True
+        assert Apply(Reference("str2bool"), Literal('t')).eval(env) == True
+        assert Apply(Reference("str2bool"), Literal('1')).eval(env) == True
+        assert Apply(Reference("str2bool"), Literal('0')).eval(env) == False
+        assert Apply(Reference("str2bool"), Literal('false')).eval(env) == False
+        assert Apply(Reference("str2num"), Literal('10')).eval(env) == 10
+        assert Apply(Reference("str2num"), Literal('10.56')).eval(env) == 10.56
+        assert Apply(Reference("str2date"), Literal('2015-01-01')).eval(env) == datetime(2015, 1, 1)
+        assert Apply(Reference("str2date"), Literal('2015-01-01T18:32:57')).eval(env) == datetime(2015, 1, 1, 18, 32, 57)
+        assert Apply(Reference("str2date"), Literal('2015-01-01T18:32:57.001200')).eval(env) == datetime(2015, 1, 1, 18, 32, 57, 1200)
 
     def test_map(self):
         env = BuiltInEnv() | DictEnv({})


### PR DESCRIPTION
@millerdev 

This allows you to map value to dates, timestamps, booleans.

Previously those would all be saved to SQL as strings.

Added docs here: https://confluence.dimagi.com/display/commcarepublic/CommCare+Data+Export+Tool#CommCareDataExportTool-E.TypeSupport