### PR TITLE
paginate by date for forms and cases

### DIFF
--- a/commcare_export/cli.py
+++ b/commcare_export/cli.py
@@ -45,8 +45,9 @@ def main(argv):
     parser.add_argument('--username')
     parser.add_argument('--password')
     parser.add_argument('--auth-mode', default='digest', help='Use "session" based auth or "digest" auth.')
-    parser.add_argument('--since')
-    parser.add_argument('--start-over', default=False, action='store_true', 
+    parser.add_argument('--since', help='Export all data after this date. Format YYYY-MM-DD or YYYY-MM-DDTHH:mm:SS')
+    parser.add_argument('--until', help='Export all data up until this date. Format YYYY-MM-DD or YYYY-MM-DDTHH:mm:SS')
+    parser.add_argument('--start-over', default=False, action='store_true',
                         help='When saving to a SQL database; the default is to pick up since the last success. This disables that.')
     parser.add_argument('--profile')
     parser.add_argument('--verbose', default=False, action='store_true')
@@ -174,7 +175,9 @@ def main_with_args(args):
 
     if args.since:
         logger.debug('Starting from %s', args.since)
-    env = BuiltInEnv() | CommCareHqEnv(api_client, since=dateutil.parser.parse(args.since) if args.since else None) | JsonPathEnv({}) 
+    since = dateutil.parser.parse(args.since) if args.since else None
+    until = dateutil.parser.parse(args.until) if args.until else None
+    env = BuiltInEnv() | CommCareHqEnv(api_client, since=since, until=until) | JsonPathEnv({})
     results = query.eval(env)
 
     # Assume that if any tables were emitted, that is the idea, otherwise print the output

--- a/commcare_export/commcare_hq_client.py
+++ b/commcare_export/commcare_hq_client.py
@@ -103,6 +103,7 @@ class CommCareHqClient(object):
         params = dict(params or {})
         def iterate_resource(resource=resource, params=params):
             more_to_fetch = True
+            last_batch_ids = set()
 
             while more_to_fetch:
                 batch = self.get(resource, params)
@@ -116,9 +117,11 @@ class CommCareHqClient(object):
                     more_to_fetch = False
                 else:
                     for obj in batch['objects']:
-                        yield obj
+                        if obj['id'] not in last_batch_ids:
+                            yield obj
 
                     if batch['meta']['next']:
+                        last_batch_ids = {obj['id'] for obj in batch['objects']}
                         params = paginator.next_page_params_from_batch(batch)
                         if not params:
                             more_to_fetch = False

--- a/commcare_export/commcare_minilinq.py
+++ b/commcare_export/commcare_minilinq.py
@@ -65,6 +65,9 @@ class CommCareHqEnv(DictEnv):
 
 
 class SimplePaginator(object):
+    """
+    Paginate based on the 'next' URL provided in the API response.
+    """
     def __init__(self, resource):
         self.resource = resource
 
@@ -97,6 +100,18 @@ class SimplePaginator(object):
 
 
 class DatePaginator(SimplePaginator):
+    """
+    This paginator is designed to get around the issue of deep paging where the deeper the page the longer
+    the query takes.
+
+    Paginate records according to a date in the record. The params for the next batch will include a filter
+    for the date of the last record in the previous batch.
+
+    This also adds an ordering parameter to ensure that the records are ordered by the date field in ascending order.
+
+    :param resource: The name of the resource being fetched: ``form`` or ``case``.
+    :param since_field: The name of the date field to use for pagination.
+    """
     def __init__(self, resource, since_field):
         super(DatePaginator, self).__init__(resource)
         self.since_field = since_field

--- a/commcare_export/commcare_minilinq.py
+++ b/commcare_export/commcare_minilinq.py
@@ -107,11 +107,12 @@ class DatePaginator(SimplePaginator):
         return params
 
     def next_page_params_from_batch(self, batch):
-        last_obj = batch['objects'][-1]
-        if not last_obj:
+        try:
+            last_obj = batch['objects'][-1]
+        except IndexError:
             return
 
-        since = last_obj.get(self.since_field)
+        since = last_obj and last_obj.get(self.since_field)
         if since:
             try:
                 since_date = datetime.strptime(since, '%Y-%m-%dT%H:%M:%SZ')

--- a/commcare_export/commcare_minilinq.py
+++ b/commcare_export/commcare_minilinq.py
@@ -1,11 +1,18 @@
 """
-CommCare/Export-specific extensions to MiniLinq. 
+CommCare/Export-specific extensions to MiniLinq.
 
 To date, this is simply built-ins for querying the
 API directly.
 """
 
 from commcare_export.env import DictEnv, CannotBind, CannotReplace
+from datetime import datetime
+
+try:
+    from urllib.parse import urlparse, parse_qs
+except ImportError:
+    from urlparse import urlparse, parse_qs
+
 
 resource_since_params = {
     'form': ('received_on_start', 'received_on_end'),
@@ -15,6 +22,17 @@ resource_since_params = {
     'application': None,
     'web-user': None,
 }
+
+def get_paginator(resource):
+    return {
+        'form': DatePaginator('form', 'received_on'),
+        'case': DatePaginator('case', 'server_date_modified'),
+        'device-log': SimplePaginator('device-log'),
+        'user': SimplePaginator('user'),
+        'application': SimplePaginator('application'),
+        'web-user': SimplePaginator('web-user'),
+    }[resource]
+
 
 class CommCareHqEnv(DictEnv):
     """
@@ -31,30 +49,72 @@ class CommCareHqEnv(DictEnv):
         })
 
     def api_data(self, resource, payload=None, include_referenced_items=None):
-        payload = dict(payload or {}) # Do not mutate passed-in dicts
-        params = {'limit': 1000}
-
         if resource not in resource_since_params:
             raise ValueError('I do not know how to access the API resource "%s"' % resource)
 
-        if (self.since or self.until) and resource_since_params[resource]:
-            since_param, until_param = resource_since_params[resource]
-            if self.since:
-                payload[since_param] = self.since.isoformat()
-
-            if self.until:
-                payload[until_param] = self.until.isoformat()
-
-        if payload:
-            params.update(payload)
-
-        if include_referenced_items:
-            params.update([ ('%s__full' % referenced_item, 'true') for referenced_item in include_referenced_items])
-        
-        return self.commcare_hq_client.iterate(resource, params=params)
+        paginator = get_paginator(resource)
+        paginator.init(payload, include_referenced_items, self.until)
+        initial_params = paginator.next_page_params_since(self.since)
+        return self.commcare_hq_client.iterate(resource, paginator, params=initial_params)
 
     def bind(self, name, value):
         raise CannotBind()
 
     def replace(self, data):
         raise CannotReplace()
+
+
+class SimplePaginator(object):
+    def __init__(self, resource):
+        self.resource = resource
+
+    def init(self, payload=None, include_referenced_items=None, until=None):
+        self.payload = dict(payload or {})  # Do not mutate passed-in dicts
+        self.include_referenced_items = include_referenced_items
+        self.until = until
+
+    def next_page_params_since(self, since=None):
+        params = self.payload
+        params['limit'] = 1000
+
+        resource_date_params = resource_since_params[self.resource]
+        if (since or self.until) and resource_date_params:
+            since_param, until_param = resource_date_params
+            if since:
+                params[since_param] = since.isoformat()
+
+            if self.until:
+                params[until_param] = self.until.isoformat()
+
+        if self.include_referenced_items:
+            params.update([('%s__full' % referenced_item, 'true') for referenced_item in self.include_referenced_items])
+
+        return params
+
+    def next_page_params_from_batch(self, batch):
+        if batch['meta']['next']:
+            return parse_qs(urlparse(batch['meta']['next']).query)
+
+
+class DatePaginator(SimplePaginator):
+    def __init__(self, resource, since_field):
+        super(DatePaginator, self).__init__(resource)
+        self.since_field = since_field
+
+    def next_page_params_since(self, since=None):
+        params = super(DatePaginator, self).next_page_params_since(since)
+        params['order_by'] = self.since_field
+        return params
+
+    def next_page_params_from_batch(self, batch):
+        last_obj = batch['objects'][-1]
+        if not last_obj:
+            return
+
+        since = last_obj.get(self.since_field)
+        if since:
+            try:
+                since_date = datetime.strptime(since, '%Y-%m-%dT%H:%M:%SZ')
+            except ValueError:
+                return
+            return self.next_page_params_since(since_date)

--- a/tests/test_commcare_hq_client.py
+++ b/tests/test_commcare_hq_client.py
@@ -81,3 +81,8 @@ class TestDatePaginator(unittest.TestCase):
     def test_empty_batch(self):
         self.assertIsNone(DatePaginator('fake', 'since').next_page_params_from_batch({'objects': []}))
 
+    def test_bad_date(self):
+        self.assertIsNone(DatePaginator('fake', 'since').next_page_params_from_batch({'objects': [{
+            'since': 'not a date'
+        }]}))
+

--- a/tests/test_commcare_hq_client.py
+++ b/tests/test_commcare_hq_client.py
@@ -15,12 +15,12 @@ class FakeSession(object):
         if params:
             result = {
                 'meta': { 'next': None, 'offset': params['offset'][0], 'limit': 1, 'total_count': 2 },
-                'objects': [ {'foo': 2} ]
+                'objects': [ {'id': 1, 'foo': 2} ]
             }
         else:
             result = {
                 'meta': { 'next': '?offset=1', 'offset': 0, 'limit': 1, 'total_count': 2 },
-                'objects': [ {'foo': 1} ]
+                'objects': [ {'id': 2, 'foo': 1} ]
             }
 
         # Mutatey construction method required by requests.Response

--- a/tests/test_commcare_hq_client.py
+++ b/tests/test_commcare_hq_client.py
@@ -70,3 +70,14 @@ class TestCommCareHqClient(unittest.TestCase):
     def test_iterate_date(self):
         self._test_iterate(FakeDateSession('form'), DatePaginator('form', 'since_field'))
         self._test_iterate(FakeDateSession('case'), DatePaginator('case', 'since_field'))
+
+
+class TestDatePaginator(unittest.TestCase):
+
+    @classmethod
+    def setup_class(cls):
+        pass
+
+    def test_empty_batch(self):
+        self.assertIsNone(DatePaginator('fake', 'since').next_page_params_from_batch({'objects': []}))
+

--- a/tests/test_commcare_hq_client.py
+++ b/tests/test_commcare_hq_client.py
@@ -1,45 +1,72 @@
 from __future__ import unicode_literals, print_function, absolute_import, division, generators, nested_scopes
 
 import unittest
+
 import simplejson
-from itertools import *
 
 import requests
 
 from commcare_export.commcare_hq_client import CommCareHqClient
-from commcare_export.commcare_minilinq import SimplePaginator
+from commcare_export.commcare_minilinq import SimplePaginator, DatePaginator, resource_since_params
 
 
 class FakeSession(object):
     def get(self, resource_url, params=None, auth=None):
-        if params:
-            result = {
-                'meta': { 'next': None, 'offset': params['offset'][0], 'limit': 1, 'total_count': 2 },
-                'objects': [ {'id': 1, 'foo': 2} ]
-            }
-        else:
-            result = {
-                'meta': { 'next': '?offset=1', 'offset': 0, 'limit': 1, 'total_count': 2 },
-                'objects': [ {'id': 2, 'foo': 1} ]
-            }
-
+        result = self._get_results(params)
         # Mutatey construction method required by requests.Response
         response = requests.Response()
         response._content = simplejson.dumps(result).encode('utf-8')
         response.status_code = 200
         return response
 
+    def _get_results(self, params):
+        if params:
+            assert params['offset'][0] == '1'
+            return {
+                'meta': { 'next': None, 'offset': params['offset'][0], 'limit': 1, 'total_count': 2 },
+                'objects': [ {'id': 1, 'foo': 2} ]
+            }
+        else:
+            return {
+                'meta': { 'next': '?offset=1', 'offset': 0, 'limit': 1, 'total_count': 2 },
+                'objects': [ {'id': 2, 'foo': 1} ]
+            }
+
+
+class FakeDateSession(FakeSession):
+    def __init__(self, resource):
+        self.since_query_param = resource_since_params[resource][0]
+
+    def _get_results(self, params):
+        if not params:
+            return {
+                'meta': {'next': '?offset=1', 'offset': 0, 'limit': 1, 'total_count': 2},
+                'objects': [{'id': 1, 'foo': 1, 'since_field': '2017-01-01T15:36:22Z'}]
+            }
+        else:
+            assert params[self.since_query_param] == '2017-01-01T15:36:22'
+            # include ID=1 again to make sure it gets filtered out
+            return {
+                'meta': { 'next': None, 'offset': 1, 'limit': 1, 'total_count': 2 },
+                'objects': [ {'id': 1, 'foo': 1}, {'id': 2, 'foo': 2} ]
+            }
+
+
 class TestCommCareHqClient(unittest.TestCase):
 
-    @classmethod
-    def setup_class(cls):
-        pass
-
-    def test_iterate(self):
-        client = CommCareHqClient('/fake/commcare-hq/url', project='fake-project', session = FakeSession())
+    def _test_iterate(self, session, paginator):
+        client = CommCareHqClient('/fake/commcare-hq/url', project='fake-project', session=session)
 
         # Iteration should do two "gets" because the first will have something in the "next" metadata field
-        results = list(client.iterate('/fake/uri', SimplePaginator('fake')))
+        paginator.init()
+        results = list(client.iterate('/fake/uri', paginator))
         self.assertEqual(len(results), 2)
         self.assertEqual(results[0]['foo'], 1)
         self.assertEqual(results[1]['foo'], 2)
+
+    def test_iterate_simple(self):
+        self._test_iterate(FakeSession(), SimplePaginator('fake'))
+
+    def test_iterate_date(self):
+        self._test_iterate(FakeDateSession('form'), DatePaginator('form', 'since_field'))
+        self._test_iterate(FakeDateSession('case'), DatePaginator('case', 'since_field'))

--- a/tests/test_commcare_hq_client.py
+++ b/tests/test_commcare_hq_client.py
@@ -7,6 +7,8 @@ from itertools import *
 import requests
 
 from commcare_export.commcare_hq_client import CommCareHqClient
+from commcare_export.commcare_minilinq import SimplePaginator
+
 
 class FakeSession(object):
     def get(self, resource_url, params=None, auth=None):
@@ -37,7 +39,7 @@ class TestCommCareHqClient(unittest.TestCase):
         client = CommCareHqClient('/fake/commcare-hq/url', project='fake-project', session = FakeSession())
 
         # Iteration should do two "gets" because the first will have something in the "next" metadata field
-        results = list(client.iterate('/fake/uri'))
+        results = list(client.iterate('/fake/uri', SimplePaginator('fake')))
         self.assertEqual(len(results), 2)
         self.assertEqual(results[0]['foo'], 1)
         self.assertEqual(results[1]['foo'], 2)

--- a/tests/test_commcare_minilinq.py
+++ b/tests/test_commcare_minilinq.py
@@ -24,11 +24,11 @@ class TestCommCareMiniLinq(unittest.TestCase):
         client = MockCommCareHqClient({
             'form': [
                 (
-                    {'limit': 1000, 'filter': 'test1'},
+                    {'limit': 1000, 'filter': 'test1', 'order_by': 'received_on'},
                     [1, 2, 3],
                 ),
                 (
-                    {'limit': 1000, 'filter': 'test2'},
+                    {'limit': 1000, 'filter': 'test2', 'order_by': 'received_on'},
                     [
                         { 'x': [{ 'y': 1 }, {'y': 2}] },
                         { 'x': [{ 'y': 3 }, {'z': 4}] },
@@ -36,18 +36,18 @@ class TestCommCareMiniLinq(unittest.TestCase):
                     ]
                 ),
                 (
-                    {'limit': 1000, 'filter': 'laziness-test'},
+                    {'limit': 1000, 'filter': 'laziness-test', 'order_by': 'received_on'},
                     (i if i < 5 else die('Not lazy enough') for i in range(12))
                 ),
                 (
-                    {'limit': 1000, 'cases__full': 'true'},
+                    {'limit': 1000, 'cases__full': 'true', 'order_by': 'received_on'},
                     [1, 2, 3, 4, 5]
                 ),
             ],
 
             'case': [
                 (
-                    {'limit': 1000, 'type': 'foo'},
+                    {'limit': 1000, 'type': 'foo', 'order_by': 'server_date_modified'},
                     [
                         { 'x': 1 },
                         { 'x': 2 },


### PR DESCRIPTION
To get around the issue of deep paging where the deeper the page the longer the query takes.