### PR TITLE
set batch checkpoint date to correct date

### DIFF
--- a/commcare_export/commcare_minilinq.py
+++ b/commcare_export/commcare_minilinq.py
@@ -176,6 +176,11 @@ class DatePaginator(SimplePaginator):
         return params
 
     def next_page_params_from_batch(self, batch):
+        since_date = self.get_since_date(batch)
+        if since_date:
+            return self.next_page_params_since(since_date)
+
+    def get_since_date(self, batch):
         try:
             last_obj = batch['objects'][-1]
         except IndexError:
@@ -183,11 +188,8 @@ class DatePaginator(SimplePaginator):
 
         since = last_obj and last_obj.get(self.since_field)
         if since:
-            since_date = None
             for fmt in ('%Y-%m-%dT%H:%M:%SZ', '%Y-%m-%dT%H:%M:%S.%fZ'):
                 try:
-                    since_date = datetime.strptime(since, fmt)
+                    return datetime.strptime(since, fmt)
                 except ValueError:
                     pass
-            if since_date:
-                return self.next_page_params_since(since_date)


### PR DESCRIPTION
The current code naively sets the checkpoint to the
datetime that the batch was downloaded as opposed to the
'since date' in the last item of the batch.

This means that any interruptions in the export
would not correctly restart from where they left off
but would instead only export data that was updated
since the last run.