### PR TITLE
checkpoint key

### DIFF
--- a/README.md
+++ b/README.md
@@ -399,7 +399,12 @@ https://github.com/dimagi/commcare-export/releases
 
 Testing databases
 -----------------
-Supported databases are PostgreSQL, MySQL, MSSQL
+Supported databases are PostgreSQL, MySQL, MSSQL.
+
+To run tests against selected databases can be done using test marks as follows:
+```
+py.test -m [postgres,mysql,mssql]
+``` 
 
 Postgresql
 ==========

--- a/commcare_export/checkpoint.py
+++ b/commcare_export/checkpoint.py
@@ -140,7 +140,7 @@ class CheckpointManager(SqlMixin):
 
     def _get_last_checkpoint(self, session, **filters):
         return session.query(Checkpoint).filter_by(**filters)\
-            .order_by(Checkpoint.since_param.desc()).first()
+            .order_by(Checkpoint.time_of_run.desc()).first()
 
     def log_warnings(self, run):
         # type: (Checkpoint) -> None

--- a/commcare_export/cli.py
+++ b/commcare_export/cli.py
@@ -182,7 +182,7 @@ def _get_writer(output_format, output, strict_types):
 
 def get_date_params(args, checkpoint_manager):
     if not args.since and not args.start_over and checkpoint_manager:
-        args.since = checkpoint_manager.get_time_of_last_run()
+        args.since = checkpoint_manager.get_time_of_last_checkpoint()
 
         if args.since:
             logger.debug('Last successful run was %s', args.since)

--- a/commcare_export/cli.py
+++ b/commcare_export/cli.py
@@ -73,6 +73,8 @@ CLI_ARGS = [
                  help="When saving to a SQL database don't allow changing column types once they are created."),
         Argument('missing-value', default=None, help="Value to use when a field is missing from the form / case."),
         Argument('batch-size', default=1000, help="Number of records to process per batch."),
+        Argument('checkpoint-key', help="Use this key for all checkpoints instead of the query file MD5 hash "
+                                        "in order to prevent table rebuilds after a query file has been edited."),
     ]
 
 
@@ -207,7 +209,7 @@ def _get_api_client(args, checkpoint_manager, commcarehq_base_url):
 def _get_checkpoint_manager(args):
     return CheckpointManager(
         args.output, args.query, misc.digest_file(args.query),
-        args.project, args.commcare_hq
+        args.project, args.commcare_hq, args.checkpoint_key
     )
 
 

--- a/commcare_export/cli.py
+++ b/commcare_export/cli.py
@@ -12,9 +12,8 @@ import dateutil.parser
 from six.moves import input
 
 from commcare_export import excel_query
-from commcare_export import misc
 from commcare_export import writers
-from commcare_export.checkpoint import CheckpointManager
+from commcare_export.utils import get_checkpoint_manager
 from commcare_export.commcare_hq_client import CommCareHqClient, LATEST_KNOWN_VERSION
 from commcare_export.commcare_minilinq import CommCareHqEnv
 from commcare_export.env import BuiltInEnv, JsonPathEnv, EmitterEnv
@@ -43,8 +42,9 @@ class Argument(object):
     def default(self):
         return self._kwargs.get('default')
 
-    def add_to_parser(self, parser):
-        parser.add_argument(*self._args, **self._kwargs)
+    def add_to_parser(self, parser, **additional_kwargs):
+        additional_kwargs.update(self._kwargs)
+        parser.add_argument(*self._args, **additional_kwargs)
 
 
 CLI_ARGS = [
@@ -206,13 +206,6 @@ def _get_api_client(args, checkpoint_manager, commcarehq_base_url):
     )
 
 
-def _get_checkpoint_manager(args):
-    return CheckpointManager(
-        args.output, args.query, misc.digest_file(args.query),
-        args.project, args.commcare_hq, args.checkpoint_key
-    )
-
-
 def main_with_args(args):
     writer = _get_writer(args.output_format, args.output, args.strict_types)
 
@@ -235,7 +228,7 @@ def main_with_args(args):
         if not os.path.exists(args.query):
             logger.warning("Checkpointing disabled for non file-based query")
         else:
-            checkpoint_manager = _get_checkpoint_manager(args)
+            checkpoint_manager = get_checkpoint_manager(args)
             checkpoint_manager.create_checkpoint_table()
 
     if not args.username:
@@ -274,6 +267,7 @@ def main_with_args(args):
 
 def entry_point():
     main(sys.argv[1:])
-    
+
+
 if __name__ == '__main__':
     entry_point()

--- a/commcare_export/cli.py
+++ b/commcare_export/cli.py
@@ -181,11 +181,14 @@ def _get_writer(output_format, output, strict_types):
 
 
 def get_date_params(args, checkpoint_manager):
+    if args.start_over and checkpoint_manager:
+        logger.warn('Ignoring all checkpoints and re-fetching all data from CommCare.')
+
     if not args.since and not args.start_over and checkpoint_manager:
         args.since = checkpoint_manager.get_time_of_last_checkpoint()
 
         if args.since:
-            logger.debug('Last successful run was %s', args.since)
+            logger.debug('Last successful checkpoint was %s', args.since)
         else:
             logger.warn('No successful runs found, and --since not specified: will import ALL data')
 

--- a/commcare_export/utils.py
+++ b/commcare_export/utils.py
@@ -1,0 +1,55 @@
+from __future__ import unicode_literals, print_function, absolute_import, division, generators, nested_scopes
+
+import sys
+
+from commcare_export import misc
+from commcare_export.checkpoint import CheckpointManager
+from six.moves import input
+
+from commcare_export.writers import StreamingMarkdownTableWriter
+
+
+def get_checkpoint_manager(args, require_query=True):
+    md5 = None
+    try:
+        md5 = misc.digest_file(args.query)
+    except Exception:
+        if require_query:
+            raise
+
+    return CheckpointManager(
+        args.output, args.query, md5,
+        args.project, args.commcare_hq, args.checkpoint_key
+    )
+
+
+def confirm(message):
+    confirm = input(
+        """
+        {}? [y/N]
+        """.format(message)
+    )
+    return confirm == "y"
+
+
+def print_runs(runs):
+    print()
+    rows = []
+    for run in runs:
+        rows.append([
+            run.time_of_run, run.since_param, "True" if run.final else "False",
+            run.project, run.query_file_name, run.query_file_md5, run.key, run.commcare
+        ])
+
+    rows = [
+        [val if val is not None else '' for val in row]
+        for row in rows
+    ]
+
+    StreamingMarkdownTableWriter(sys.stdout, compute_widths=True).write_table({
+        'headings': [
+            "Checkpoint Time", "Batch end date", "Export Complete",
+            "Project", "Query Filename", "Query MD5", "Key", "CommCare HQ"
+        ],
+        'rows': rows
+    })

--- a/commcare_export/utils_cli.py
+++ b/commcare_export/utils_cli.py
@@ -26,8 +26,12 @@ class BaseCommand(object):
 
 
 class ListHistoryCommand(BaseCommand):
-    slug = 'list-history'
-    help = """List export history. History will be filtered by arguments provided."""
+    slug = 'history'
+    help = """List export history. History will be filtered by arguments provided.
+    
+    This command only applies when exporting to a SQL database. The command lists
+    the checkpoints that have been created by the command.
+    """
 
     @classmethod
     def add_arguments(cls, parser):
@@ -51,7 +55,7 @@ class ListHistoryCommand(BaseCommand):
         if manager.key:
             print("    key:            {}".format(manager.key))
 
-        runs = manager.list_runs(args.limit)
+        runs = manager.list_checkpoints(args.limit)
         print_runs(runs)
 
 
@@ -90,14 +94,14 @@ class SetKeyCommand(BaseCommand):
     def run(self, args):
         key = args.checkpoint_key
         manager = get_checkpoint_manager(args)
-        run_with_key = manager.get_last_run()
+        run_with_key = manager.get_last_checkpoint()
 
         if run_with_key:
             print("A checkpoint with that key already exists.")
             return
 
         manager.key = None
-        run_no_key = manager.get_last_run()
+        run_no_key = manager.get_last_checkpoint()
 
         if not run_no_key:
             print(args)
@@ -107,7 +111,7 @@ class SetKeyCommand(BaseCommand):
         print_runs([run_no_key])
         if confirm("Do you want to set the key for this checkpoint to '{}'".format(key)):
             run_no_key.key = key
-            manager.update_run(run_no_key)
+            manager.update_checkpoint(run_no_key)
 
         print("\nUpdated checkpoint:")
         print_runs([run_no_key])

--- a/commcare_export/utils_cli.py
+++ b/commcare_export/utils_cli.py
@@ -1,0 +1,161 @@
+from __future__ import unicode_literals, print_function, absolute_import, division, generators, nested_scopes
+
+import argparse
+import inspect
+import logging
+import sys
+
+from commcare_export.cli import CLI_ARGS
+from commcare_export.utils import get_checkpoint_manager, confirm, print_runs
+
+EXIT_STATUS_ERROR = 1
+
+logger = logging.getLogger(__name__)
+
+
+class BaseCommand(object):
+    slug = None
+    help = None
+
+    @classmethod
+    def add_arguments(cls, parser):
+        raise NotImplementedError
+
+    def run(self, args):
+        raise NotImplementedError
+
+
+class ListHistoryCommand(BaseCommand):
+    slug = 'list-history'
+    help = """List export history. History will be filtered by arguments provided."""
+
+    @classmethod
+    def add_arguments(cls, parser):
+        parser.add_argument('--limit', default=10, help="Limit the number of export runs to display")
+        parser.add_argument('--output', required=True, help='SQL Database URL')
+        shared_args = {'project', 'query', 'checkpoint_key', 'commcare_hq'}
+        for arg in CLI_ARGS:
+            if arg.name in shared_args:
+                arg.add_to_parser(parser)
+
+    def run(self, args):
+        manager = get_checkpoint_manager(args, require_query=False)
+
+        print("Listing checkpoints (most recent {}):".format(args.limit))
+        if args.project:
+            print("    project:        {}".format(args.project))
+        if args.commcare_hq != 'prod':
+            print("    commcare-hq:    {}".format(args.commcare_hq))
+        if args.query:
+            print("    query filename: {}".format(args.query))
+        if manager.key:
+            print("    key:            {}".format(manager.key))
+
+        runs = manager.list_runs(args.limit)
+        print_runs(runs)
+
+
+class SetKeyCommand(BaseCommand):
+    slug = 'set-checkpoint-key'
+    help = """Set the key for a particular checkpoint.
+
+    This command is used to migrate an non-keyed checkpoint to a keyed checkpoint.
+
+    This is useful if you already have a populated export database and do not wish to trigger
+    rebuilds after editing the query file.
+
+    For example, you've been running the export tool with query file A.xlsx and have a fully populated
+    database. Now you need to add an extra column to the table but only want to populate it with new data.
+
+    What you need to do is update your current checkpoint with a key that you can then use when running
+    the command from now on.
+
+      $ commcare-export-utils set-key --project X --query A.xlsx --output [SQL URL] --checkpoint-key my-key
+
+    Now when you run the export tool in future you can use this key:
+
+      $ commcare-export --project X --query A.xlsx --output [SQL URL] --checkpoint-key my-key ...
+    """
+
+    @classmethod
+    def add_arguments(cls, parser):
+        parser.add_argument('--output', required=True, help='SQL Database URL')
+        shared_args = {'project', 'query', 'checkpoint_key'}
+        for arg in CLI_ARGS:
+            if arg.name in shared_args:
+                arg.add_to_parser(parser, required=True)
+            elif arg.name == 'commcare_hq':
+                arg.add_to_parser(parser)
+
+    def run(self, args):
+        key = args.checkpoint_key
+        manager = get_checkpoint_manager(args)
+        run_with_key = manager.get_last_run()
+
+        if run_with_key:
+            print("A checkpoint with that key already exists.")
+            return
+
+        manager.key = None
+        run_no_key = manager.get_last_run()
+
+        if not run_no_key:
+            print(args)
+            print("No checkpoint found with args matching those provided.")
+            return
+
+        print_runs([run_no_key])
+        if confirm("Do you want to set the key for this checkpoint to '{}'".format(key)):
+            run_no_key.key = key
+            manager.update_run(run_no_key)
+
+        print("\nUpdated checkpoint:")
+        print_runs([run_no_key])
+
+
+COMMANDS = [
+    ListHistoryCommand,
+    SetKeyCommand
+]
+
+
+def main(argv):
+    parser = argparse.ArgumentParser('commcare-export-utils')
+    subparsers = parser.add_subparsers(dest='command')
+    for command_type in COMMANDS:
+        sub = subparsers.add_parser(
+            command_type.slug,
+            help=inspect.cleandoc(command_type.help).splitlines()[0],
+            description=inspect.cleandoc(command_type.help),
+            formatter_class=argparse.RawDescriptionHelpFormatter
+        )
+        command_type.add_arguments(sub)
+
+    try:
+        args = parser.parse_args(argv)
+    except UnicodeDecodeError:
+        for arg in argv:
+            try:
+                arg.encode('utf-8')
+            except UnicodeDecodeError:
+                sys.stderr.write(u"ERROR: Argument '%s' contains unicode characters. "
+                                 u"Only ASCII characters are supported.\n" % unicode(arg, 'utf-8'))
+        sys.exit(1)
+
+    logging.basicConfig(level=logging.WARN,
+                        format='%(asctime)s %(name)-12s %(levelname)-8s %(message)s')
+
+    exit(main_with_args(args))
+
+
+def main_with_args(args):
+    command = [c for c in COMMANDS if c.slug == args.command][0]
+    command().run(args)
+
+
+def entry_point():
+    main(sys.argv[1:])
+
+
+if __name__ == '__main__':
+    entry_point()

--- a/migrations/versions/d82e1d06a82c_add_key_column.py
+++ b/migrations/versions/d82e1d06a82c_add_key_column.py
@@ -1,0 +1,27 @@
+"""add key column
+
+Revision ID: d82e1d06a82c
+Revises: 53f1aad98e33
+Create Date: 2018-08-15 12:08:51.720796
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = 'd82e1d06a82c'
+down_revision = '53f1aad98e33'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    url = op.get_bind().engine.url
+    collation = 'utf8_bin' if 'mysql' in url.drivername else None
+    op.add_column(
+        'commcare_export_runs',
+        sa.Column('key', sa.Unicode(255, collation=collation))
+    )
+
+def downgrade():
+    op.drop_column('commcare_export_runs', 'key')

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,12 @@ setuptools.setup(
     author = 'Dimagi',
     author_email = 'information@dimagi.com',
     url = "https://github.com/dimagi/commcare-export",
-    entry_points = { 'console_scripts': ['commcare-export = commcare_export.cli:entry_point'] },
+    entry_points = {
+        'console_scripts': [
+            'commcare-export = commcare_export.cli:entry_point',
+            'commcare-export-utils = commcare_export.utils_cli:entry_point'
+        ]
+    },
     packages = setuptools.find_packages(exclude=['tests*']),
     data_files = [
         (os.path.join('share', 'commcare-export', 'examples'), glob.glob('examples/*.json') + glob.glob('examples/*.xlsx')),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -46,17 +46,17 @@ def _db_params(request, db_name):
 
 
 @pytest.fixture(scope="class", params=[
-    {
+    pytest.param({
         'url': "postgresql://postgres@localhost/%s",
         'admin_db': 'postgres'
-    },
-    {
+    }, marks=pytest.mark.postgres),
+    pytest.param({
         'url': 'mysql+pymysql://travis@/%s?charset=utf8',
-    },
-    {
+    }, marks=pytest.mark.mysql),
+    pytest.param({
         'url': 'mssql+pyodbc://SA:Password@123@localhost/%s?driver=ODBC+Driver+17+for+SQL+Server',
         'admin_db': 'master'
-    }
+    }, marks=pytest.mark.mssql)
 ], ids=['postgres', 'mysql', 'mssql'])
 def db_params(request):
     return _db_params(request, TEST_DB)

--- a/tests/test_checkpointmanager.py
+++ b/tests/test_checkpointmanager.py
@@ -37,15 +37,15 @@ class TestCheckpointManager(object):
             manager.connection.execute(sqlalchemy.sql.text('DROP TABLE alembic_version'))
         manager.create_checkpoint_table()
 
-    def test_get_time_of_last_run(self, manager):
+    def test_get_time_of_last_checkpoint(self, manager):
         manager.create_checkpoint_table()
         manager.set_batch_checkpoint(datetime.datetime.utcnow())
         second_run = datetime.datetime.utcnow()
         manager.set_batch_checkpoint(second_run)
 
-        assert manager.get_time_of_last_run() == second_run.isoformat()
+        assert manager.get_time_of_last_checkpoint() == second_run.isoformat()
 
-    def test_get_time_of_last_run_no_args(self, manager):
+    def test_get_time_of_last_checkpoint_no_args(self, manager):
         # test that we can still get the time of last run no project and commcare args
         manager.create_checkpoint_table()
         with session_scope(manager.Session) as session:
@@ -60,7 +60,7 @@ class TestCheckpointManager(object):
                 time_of_run=datetime.datetime.utcnow().isoformat(),
                 final=True
             ))
-        assert manager.get_time_of_last_run() == since_param
+        assert manager.get_time_of_last_checkpoint() == since_param
 
     def test_clean_on_final_run(self, manager):
         manager.create_checkpoint_table()
@@ -75,13 +75,13 @@ class TestCheckpointManager(object):
         manager.set_final_checkpoint()
         assert _get_non_final_rows_count() == 0
 
-    def test_get_time_of_last_run__with_key(self, manager):
+    def test_get_time_of_last_checkpoint__with_key(self, manager):
         manager.create_checkpoint_table()
         manager.key = 'my key'
         last_run_time = datetime.datetime.utcnow()
         manager.set_batch_checkpoint(last_run_time)
 
-        assert manager.get_time_of_last_run() == last_run_time.isoformat()
+        assert manager.get_time_of_last_checkpoint() == last_run_time.isoformat()
         manager.key = None
-        assert manager.get_time_of_last_run() is None
+        assert manager.get_time_of_last_checkpoint() is None
 

--- a/tests/test_checkpointmanager.py
+++ b/tests/test_checkpointmanager.py
@@ -74,3 +74,14 @@ class TestCheckpointManager(object):
         assert _get_non_final_rows_count() == 2
         manager.set_final_checkpoint()
         assert _get_non_final_rows_count() == 0
+
+    def test_get_time_of_last_run__with_key(self, manager):
+        manager.create_checkpoint_table()
+        manager.key = 'my key'
+        last_run_time = datetime.datetime.utcnow()
+        manager.set_batch_checkpoint(last_run_time)
+
+        assert manager.get_time_of_last_run() == last_run_time.isoformat()
+        manager.key = None
+        assert manager.get_time_of_last_run() is None
+

--- a/tests/test_checkpointmanager.py
+++ b/tests/test_checkpointmanager.py
@@ -7,7 +7,7 @@ import uuid
 import pytest
 import sqlalchemy
 
-from commcare_export.checkpoint import CheckpointManager, ExportRun, session_scope
+from commcare_export.checkpoint import CheckpointManager, Checkpoint, session_scope
 
 
 @pytest.fixture()
@@ -50,7 +50,7 @@ class TestCheckpointManager(object):
         manager.create_checkpoint_table()
         with session_scope(manager.Session) as session:
             since_param = datetime.datetime.utcnow().isoformat()
-            session.add(ExportRun(
+            session.add(Checkpoint(
                 id=uuid.uuid4().hex,
                 query_file_name=manager.query,
                 query_file_md5=manager.query_md5,
@@ -69,7 +69,7 @@ class TestCheckpointManager(object):
 
         def _get_non_final_rows_count():
             with session_scope(manager.Session) as session:
-                return session.query(ExportRun).filter_by(final=False).count()
+                return session.query(Checkpoint).filter_by(final=False).count()
 
         assert _get_non_final_rows_count() == 2
         manager.set_final_checkpoint()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -138,7 +138,7 @@ class TestCLIIntegrationTests(object):
 
             # have to mock these to override the pool class otherwise they hold the db connection open
             writer_patch = mock.patch('commcare_export.cli._get_writer', return_value=writer)
-            checkpoint_patch = mock.patch('commcare_export.cli._get_checkpoint_manager', return_value=checkpoint_manager)
+            checkpoint_patch = mock.patch('commcare_export.cli.get_checkpoint_manager', return_value=checkpoint_manager)
             with writer_patch, checkpoint_patch:
                 main_with_args(args)
 


### PR DESCRIPTION
This addresses https://github.com/dimagi/commcare-export/issues/94 by adding a new command line parameter `checkpoint-key`.

When that param is supplied the tool will use it as the search key for finding previous checkpoints instead of the query file MD5. Triggering a full rebuild can be done either by changing the value of the key parameter or using the `--start-over` param.

This PR also includes a tool to assist in going from non-keyed mode to keyed mode without losing history.

Easiest reviewed per commit.