### PR TITLE
don't set checkpoint based on the current time

### DIFF
--- a/commcare_export/checkpoint.py
+++ b/commcare_export/checkpoint.py
@@ -86,7 +86,6 @@ class CheckpointManager(SqlMixin):
 
     def _set_checkpoint(self, checkpoint_time, final):
         logger.info('Setting %s checkpoint: %s', 'final' if final else 'batch', checkpoint_time)
-        checkpoint_time = checkpoint_time or datetime.datetime.utcnow()
         with session_scope(self.Session) as session:
             session.add(Checkpoint(
                 id=uuid.uuid4().hex,
@@ -95,7 +94,7 @@ class CheckpointManager(SqlMixin):
                 key=self.key,
                 project=self.project,
                 commcare=self.commcare,
-                since_param=checkpoint_time.isoformat(),
+                since_param=checkpoint_time.isoformat() if checkpoint_time else '',
                 time_of_run=datetime.datetime.utcnow().isoformat(),
                 final=final
             ))

--- a/commcare_export/checkpoint.py
+++ b/commcare_export/checkpoint.py
@@ -12,6 +12,7 @@ from sqlalchemy import Column, String, Boolean
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import sessionmaker
 
+from commcare_export.exceptions import DataExportException
 from commcare_export.writers import SqlMixin
 
 logger = logging.getLogger(__name__)
@@ -86,6 +87,8 @@ class CheckpointManager(SqlMixin):
 
     def _set_checkpoint(self, checkpoint_time, final):
         logger.info('Setting %s checkpoint: %s', 'final' if final else 'batch', checkpoint_time)
+        if not checkpoint_time:
+            raise DataExportException('Tried to set an empty checkpoint. This is not allowed.')
         with session_scope(self.Session) as session:
             session.add(Checkpoint(
                 id=uuid.uuid4().hex,

--- a/commcare_export/checkpoint.py
+++ b/commcare_export/checkpoint.py
@@ -97,7 +97,7 @@ class CheckpointManager(SqlMixin):
                 key=self.key,
                 project=self.project,
                 commcare=self.commcare,
-                since_param=checkpoint_time.isoformat() if checkpoint_time else '',
+                since_param=checkpoint_time.isoformat(),
                 time_of_run=datetime.datetime.utcnow().isoformat(),
                 final=final
             ))

--- a/commcare_export/commcare_hq_client.py
+++ b/commcare_export/commcare_hq_client.py
@@ -151,6 +151,8 @@ class CommCareHqClient(object):
             since_date = paginator.get_since_date(batch)
             if since_date:
                 self._checkpoint_manager.set_batch_checkpoint(checkpoint_time=since_date)
+            else:
+                logger.warning('Failed to get a checkpoint date from a batch of data.')
 
 
 class MockCommCareHqClient(object):

--- a/commcare_export/commcare_hq_client.py
+++ b/commcare_export/commcare_hq_client.py
@@ -149,7 +149,8 @@ class CommCareHqClient(object):
         from commcare_export.commcare_minilinq import DatePaginator
         if self._checkpoint_manager and isinstance(paginator, DatePaginator):
             since_date = paginator.get_since_date(batch)
-            self._checkpoint_manager.set_batch_checkpoint(checkpoint_time=since_date)
+            if since_date:
+                self._checkpoint_manager.set_batch_checkpoint(checkpoint_time=since_date)
 
 
 class MockCommCareHqClient(object):

--- a/commcare_export/commcare_hq_client.py
+++ b/commcare_export/commcare_hq_client.py
@@ -141,7 +141,7 @@ class CommCareHqClient(object):
                     else:
                         more_to_fetch = False
 
-                self.checkpoint(paginator, batch)
+                    self.checkpoint(paginator, batch)
                 
         return RepeatableIterator(iterate_resource)
 


### PR DESCRIPTION
@snopoke I'm not 100% sure about this but I think this is a potentially big oversight in the tool that could be causing lost/missing data.

What we observed when doing the local ingestions on ICDS was that the final checkpoint got set to today, even though we only ever saw data through September 2018 (or whenever).

By using the system's local time to set the checkpoint on the last request you are essentially saying that the server APIs can never get behind. This is obviously heavily exacerbated in the scenario we are using, but we know that ES gets behind all the time which I think could create gaps in the exports in steady state if people's exports are relying on local system time for the last checkpoint.

Note: this means the last checkpoint will not ever be set (assuming the tool terminates with empty API results) because [last_run will be empty here](https://github.com/dimagi/commcare-export/blob/master/commcare_export/checkpoint.py#L82-L83)

HT to @bderenzi for pointing this out.