### PR TITLE
add sha1 filter

### DIFF
--- a/commcare_export/env.py
+++ b/commcare_export/env.py
@@ -299,9 +299,8 @@ def sha1(val):
     if _not_val(val):
         return None
 
-    if not isinstance(val, six.text_type):
-        val = six.text_type(val)
-    val = val.encode('utf8')
+    if not isinstance(val, bytes):
+        val = six.text_type(val).encode('utf8')
 
     return hashlib.sha1(val).hexdigest()
 

--- a/commcare_export/env.py
+++ b/commcare_export/env.py
@@ -1,4 +1,6 @@
 from __future__ import unicode_literals, print_function, absolute_import, division, generators, nested_scopes
+
+import hashlib
 from datetime import datetime
 import operator
 import pytz
@@ -293,6 +295,18 @@ def bool2int(val):
 
 
 @unwrap('val')
+def sha1(val):
+    if _not_val(val):
+        return None
+
+    if not isinstance(val, six.text_type):
+        val = six.text_type(val)
+    val = val.encode('utf8')
+
+    return hashlib.sha1(val).hexdigest()
+
+
+@unwrap('val')
 def selected_at(val, index):
     if not val:
         return None
@@ -410,6 +424,7 @@ class BuiltInEnv(DictEnv):
             'attachment_url': attachment_url,
             'filter_empty': _not_val,
             'or': _or,
+            'sha1': sha1,
         })
         return super(BuiltInEnv, self).__init__(d)
 

--- a/tests/test_minilinq.py
+++ b/tests/test_minilinq.py
@@ -88,6 +88,9 @@ class TestMiniLinq(unittest.TestCase):
         assert Apply(Reference("default"), Literal(None), Literal('a')).eval(env) == 'a'
         assert Apply(Reference("default"), Literal('b'), Literal('a')).eval(env) == 'b'
         assert Apply(Reference("count-selected"), Literal(u'a bb 日本')).eval(env) == 3
+        assert Apply(Reference("sha1"), Literal(u'a bb 日本')).eval(env) == 'e25a54025417b06d88d40baa8c71f6eee9c07fb1'
+        assert Apply(Reference("sha1"), Literal(b'2015')).eval(env) == 'd8e9fec0038ade95f6fd6cfbd3c3c344897594ba'
+        assert Apply(Reference("sha1"), Literal(2015)).eval(env) == '9cdda67ded3f25811728276cefa76b80913b4c54'
 
     def test_or(self):
         env = BuiltInEnv()

--- a/tests/test_minilinq.py
+++ b/tests/test_minilinq.py
@@ -89,7 +89,7 @@ class TestMiniLinq(unittest.TestCase):
         assert Apply(Reference("default"), Literal('b'), Literal('a')).eval(env) == 'b'
         assert Apply(Reference("count-selected"), Literal(u'a bb 日本')).eval(env) == 3
         assert Apply(Reference("sha1"), Literal(u'a bb 日本')).eval(env) == 'e25a54025417b06d88d40baa8c71f6eee9c07fb1'
-        assert Apply(Reference("sha1"), Literal(b'2015')).eval(env) == 'd8e9fec0038ade95f6fd6cfbd3c3c344897594ba'
+        assert Apply(Reference("sha1"), Literal(b'2015')).eval(env) == '9cdda67ded3f25811728276cefa76b80913b4c54'
         assert Apply(Reference("sha1"), Literal(2015)).eval(env) == '9cdda67ded3f25811728276cefa76b80913b4c54'
 
     def test_or(self):


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/HI-707

This will allow creating SHA1 hashes of any column values. The specific use case is when exporting repeat groups the 'ID' field can be a long string which is too long for the column to accommodate:

```
'319e866e-c20a-413a-b1d9-fa2471f19cdc.form.data_fisher.319e866e-c20a-413a-b1d9-fa2471f19cdc.form.data_fisher.[0].details_capture.319e866e-c20a-413a-b1d9-fa2471f19cdc.form.data_fisher.319e866e-c20a-413a-b1d9-fa2471f19cdc.form.data_fisher.[0].details_capture.[0]'
```

Adding the `sha1` to the query file will convert the long value to a hash while still maintaining the uniqueness of the key.