### PR TITLE
Simplified --with-organization change

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,8 @@ $ commcare-export --commcare-hq <URL or alias like "local" or "prod"> \
                   --output-format <csv, xls, xlsx, json, markdown, sql> \
                   --output <file name or SQL database URL> \
                   --users <export data about project's mobile workers> \
-                  --locations <export data about project's location hierarchy>
+                  --locations <export data about project's location hierarchy> \
+                  --with-organization <export users, locations and joinable form or case tables>
 ```
 
 See `commcare-export --help` for the full list of options.
@@ -127,9 +128,11 @@ User and Location Data
 ----------------------
 
 The --users and --locations options export data from a CommCare project that
-can be joined with form and case data. Specifiying the --users option will
-export an additional table named 'commcare_users' containing the following
-columns:
+can be joined with form and case data. The --with-organization option does all
+of that and adds a field to Excel query specifications to be joined on.
+
+Specifiying the --users option or --with-organization option will export an
+additional table named 'commcare_users' containing the following columns:
 
 Column                           | Type | Note
 ------                           | ---- | ----
@@ -150,8 +153,8 @@ username                         | Text |
 The data in the 'commcare_users' table comes from the [List Mobile Workers
 API endpoint](https://confluence.dimagi.com/display/commcarepublic/List+Mobile+Workers).
 
-Specifying the --locations option will export an additional table named
-'commcare_locations' containing the following columns:
+Specifying the --locations option or --with-organization options will export
+an additional table named 'commcare_locations' containing the following columns:
 
 Column                       | Type | Note
 ------                       | ---- | ----
@@ -172,14 +175,58 @@ location_type_administrative | Text |
 location_type_code           | Text |
 location_type_name           | Text |
 location_type_parent         | Text |
+<location level code>        | Text | Column name depends on project's organization
+<location level code>        | Text | Column name depends on project's organization
 
 The data in the 'commcare_locations' table comes from the Location API
 endpoint along with some additional columns from the Location Type API
-endpoint.
+endpoint. The last columns in the table exist if you have set up
+organization levels for your projects. One column is created for each
+organization level. The column name is derived from the Location Type
+that you specified. The column value is the location_id of the containing
+location at that level of your organization. Consider the example organization
+from the [CommCare help page]
+((https://confluence.dimagi.com/display/commcarepublic/Setting+up+Organization+Levels+and+Structure). A piece of the 'commcare_locations' table could look
+like this:
+
+location_id | location_type_name | chw    | supervisor | clinic | district
+----------- | ------------------ | ------ | ---------- | ------ | --------
+939fa8      | District           | NULL   | NULL       | NULL   | 939fa8
+c4cbef      | Clinic             | NULL   | NULL       | c4cbef | 939fa8
+a9ca40      | Supervisor         | NULL   | a9ca40     | c4cbef | 939fa8
+4545b9      | CHW                | 4545b9 | a9ca40     | c4cbef | 939fa8
+
+In order to join form or case data to 'commcare_users' and 'commcare_locations'
+the exported forms and cases need to contain a field identifying which user
+submitted them. The --with-organization option automatically adds a field
+called 'commcare_userid' to each query in an Excel specifiction for this
+purpose. Using that field, you can use a SQL query with a join to report
+data about any level of you organization. For example, to count the number
+of forms submitted by all workers in each clinic:
+
+```sql
+SELECT l.clinic,
+       COUNT(*)
+FROM form_table t
+LEFT JOIN (commcare_users u
+           LEFT JOIN commcare_locations l
+           ON u.commcare_location_id = l.location_id)
+ON t.commcare_userid = u.id
+GROUP BY l.clinic;
+```
 
 Note that the table names 'commcare_users' and 'commcare_locations' are
 treated as reserved names and the export tool will produce an error if
 given a query specification that writes to either of them.
+
+The export tool will write all users to 'commcare_users' and all locations to
+'commcare_locations', overwriting existing rows with current data and adding
+rows for new users and locations. If you want to remove obsolete users or
+locations from your tables, drop them and the next export will leave only
+the current ones. If you modify your organization to add or delete levels,
+you will change the columns of the 'commcare_locations' table and it is
+very likely you will want to drop the table before exporting with the new
+organization.
 
 Python Library Usage
 --------------------

--- a/README.md
+++ b/README.md
@@ -169,6 +169,7 @@ location_id                  | Text | Primary key
 location_type                | Text |
 longitude                    | Text |
 name                         | Text |
+parent                       | Text | Resource URI of parent location
 resource_uri                 | Text |
 site_code                    | Text |
 location_type_administrative | Text |

--- a/README.md
+++ b/README.md
@@ -185,9 +185,8 @@ organization levels for your projects. One column is created for each
 organization level. The column name is derived from the Location Type
 that you specified. The column value is the location_id of the containing
 location at that level of your organization. Consider the example organization
-from the [CommCare help page]
-(https://confluence.dimagi.com/display/commcarepublic/Setting+up+Organization+Levels+and+Structure). A piece of the 'commcare_locations' table could look
-like this:
+from the [CommCare help page](https://confluence.dimagi.com/display/commcarepublic/Setting+up+Organization+Levels+and+Structure).
+A piece of the 'commcare_locations' table could look like this:
 
 location_id | location_type_name | chw    | supervisor | clinic | district
 ----------- | ------------------ | ------ | ---------- | ------ | --------

--- a/README.md
+++ b/README.md
@@ -175,8 +175,8 @@ location_type_administrative | Text |
 location_type_code           | Text |
 location_type_name           | Text |
 location_type_parent         | Text |
-<location level code>        | Text | Column name depends on project's organization
-<location level code>        | Text | Column name depends on project's organization
+*location level code*        | Text | Column name depends on project's organization
+*location level code*        | Text | Column name depends on project's organization
 
 The data in the 'commcare_locations' table comes from the Location API
 endpoint along with some additional columns from the Location Type API
@@ -186,7 +186,7 @@ organization level. The column name is derived from the Location Type
 that you specified. The column value is the location_id of the containing
 location at that level of your organization. Consider the example organization
 from the [CommCare help page]
-((https://confluence.dimagi.com/display/commcarepublic/Setting+up+Organization+Levels+and+Structure). A piece of the 'commcare_locations' table could look
+(https://confluence.dimagi.com/display/commcarepublic/Setting+up+Organization+Levels+and+Structure). A piece of the 'commcare_locations' table could look
 like this:
 
 location_id | location_type_name | chw    | supervisor | clinic | district

--- a/commcare_export/builtin_queries.py
+++ b/commcare_export/builtin_queries.py
@@ -1,3 +1,4 @@
+import re
 
 from commcare_export import excel_query
 from commcare_export.minilinq import Apply, List, Literal, Reference
@@ -69,7 +70,8 @@ def get_locations_query(lp):
 
     # The input names are codes produced by Django's slugify utility
     # method. Replace hyphens with underscores to be easier to use in SQL.
-    hyphen_to_underscore = str.maketrans({'-': '_'})
+    def sql_column_name(code):
+        return re.sub('-', '_', code)
 
     location_columns = [
         Column('id', 'id'),
@@ -94,9 +96,9 @@ def get_locations_query(lp):
                'get_location_info', Literal('name')),
         Column('location_type_parent', 'location_type',
                'get_location_info', Literal('parent')),
-    ] + [Column(name.translate(hyphen_to_underscore),
+    ] + [Column(sql_column_name(code),
                 'resource_uri', 'get_location_ancestor',
-                Literal(name)) for name in location_codes]
+                Literal(code)) for code in location_codes]
     return compile_query(location_columns, 'location',
                          LOCATIONS_TABLE_NAME)
 

--- a/commcare_export/cli.py
+++ b/commcare_export/cli.py
@@ -85,6 +85,10 @@ CLI_ARGS = [
         Argument('locations', default=False, action='store_true',
                  help="Export a table containing data about this project's "
                       "locations"),
+        Argument('with-organization', default=False, action='store_true',
+                 help="Export tables containing mobile worker data and "
+                      "location data and add a commcare_userid field to any "
+                      "exported form or case"),
     ]
 
 
@@ -141,45 +145,46 @@ def main(argv):
             stats.print_stats(100)
 
 
-def _get_query(args, writer):
+def _get_query(args, writer, column_enforcer=None):
     return _get_query_from_file(
         args.query,
         args.missing_value,
         writer.supports_multi_table_write,
         writer.max_column_length,
-        writer.required_columns
+        writer.required_columns,
+        column_enforcer
     )
 
-def _get_query_from_file(query_arg, missing_value, combine_emits, max_column_length, required_columns):
+def _get_query_from_file(query_arg, missing_value, combine_emits,
+                         max_column_length, required_columns, column_enforcer):
     if os.path.exists(query_arg):
         if os.path.splitext(query_arg)[1] in ['.xls', '.xlsx']:
             import openpyxl
             workbook = openpyxl.load_workbook(query_arg)
             return excel_query.get_queries_from_excel(
                 workbook, missing_value, combine_emits,
-                max_column_length, required_columns
+                max_column_length, required_columns, column_enforcer
             )
         else:
             with io.open(query_arg, encoding='utf-8') as fh:
                 return MiniLinq.from_jvalue(json.loads(fh.read()))
 
-
-def get_queries(args, writer):
+def get_queries(args, writer, lp, column_enforcer=None):
     query_list = []
     if args.query is not None:
-        query = _get_query(args, writer)
+        query = _get_query(args, writer, column_enforcer=column_enforcer)
 
         if not query:
             raise MissingQueryFileException(args.query)
         query_list.append(query)
 
-    if args.users:
+    if args.users or args.with_organization:
         # Add user data to query
         query_list.append(builtin_queries.users_query)
 
-    if args.locations:
+    if args.locations or args.with_organization:
         # Add location data to query
-        query_list.append(builtin_queries.locations_query)
+        query_list.append(builtin_queries.get_locations_query(lp))
 
     return List(query_list) if len(query_list) > 1 else query_list[0]
 
@@ -271,8 +276,15 @@ def main_with_args(args):
               '--query, --users, --locations', file=sys.stderr)
         return EXIT_STATUS_ERROR
 
+    column_enforcer = None
+    if args.with_organization:
+        column_enforcer = builtin_queries.ColumnEnforcer()
+
+    commcarehq_base_url = commcare_hq_aliases.get(args.commcare_hq, args.commcare_hq)
+    api_client = _get_api_client(args, commcarehq_base_url)
+    lp = LocationInfoProvider(api_client, page_size=args.batch_size)
     try:
-        query = get_queries(args, writer)
+        query = get_queries(args, writer, lp, column_enforcer)
     except DataExportException as e:
         print(e.message, file=sys.stderr)
         return EXIT_STATUS_ERROR
@@ -292,9 +304,6 @@ def main_with_args(args):
         # Windows getpass does not accept unicode
         args.password = getpass.getpass()
 
-    commcarehq_base_url = commcare_hq_aliases.get(args.commcare_hq, args.commcare_hq)
-    api_client = _get_api_client(args, commcarehq_base_url)
-
     since, until = get_date_params(args)
     if args.start_over:
         if checkpoint_manager:
@@ -303,11 +312,11 @@ def main_with_args(args):
         logger.debug('Starting from %s', args.since)
 
     cm = CheckpointManagerProvider(checkpoint_manager, since, args.start_over)
-    lp = LocationInfoProvider(api_client)
     static_env = {
         'commcarehq_base_url': commcarehq_base_url,
         'get_checkpoint_manager': cm.get_checkpoint_manager,
-        'get_location_info': lp.get_location_info
+        'get_location_info': lp.get_location_info,
+        'get_location_ancestor': lp.get_location_ancestor
     }
     env = (
             BuiltInEnv(static_env)

--- a/commcare_export/location_info_provider.py
+++ b/commcare_export/location_info_provider.py
@@ -1,4 +1,5 @@
 from commcare_export.misc import unwrap_val
+from commcare_export.commcare_minilinq import SimplePaginator
 
 # LocationInfoProvider uses the /location_type/ endpoint of the API
 # to retrieve location type data, stores that information in a dictionary
@@ -6,29 +7,75 @@ from commcare_export.misc import unwrap_val
 # extract values from the dictionary.
 
 class LocationInfoProvider:
-    def __init__(self, api_client):
+    def __init__(self, api_client, page_size):
         self._api_client = api_client
+        self._page_size = page_size
         self._location_types = None
+        self._location_hierarchy = None
 
     @property
     def location_types(self):
         if self._location_types is None:
-            self._location_types = get_location_types(self._api_client)
+            self._location_types = self.get_location_types()
         return self._location_types
 
     def get_location_info(self, resource_uri, field):
         unwrapped_uri = unwrap_val(resource_uri)
-        location_type = self.location_types[unwrapped_uri]
-        if location_type is None:
-            return None
-        else:
-            return location_type[field]
+        if unwrapped_uri in self.location_types:
+            location_type = self.location_types[unwrapped_uri]
+            if field in self.location_types[unwrapped_uri]:
+                return location_type[field]
+        return None
 
-def get_location_types(api_client):
-    response = api_client.get('location_type')
-    location_type_dict = {}
-    for row in response['objects']:
-        location_type_dict[row['resource_uri']] = row
-    return location_type_dict
+    def get_location_ancestor(self, resource_uri, location_type_code):
+        unwrapped_uri = unwrap_val(resource_uri)
+        if unwrapped_uri in self.location_hierarchy:
+            location_hierarchy = self.location_hierarchy[unwrapped_uri]
+            if location_type_code in location_hierarchy:
+                return location_hierarchy[location_type_code]
+        return None
+
+    def get_location_types(self):
+        paginator = SimplePaginator('location_type', self._page_size)
+        paginator.init(None, False, None)
+        location_type_dict = {}
+        for row in self._api_client.iterate('location_type', paginator,
+                                              {'limit': self._page_size}):
+            location_type_dict[row['resource_uri']] = row
+        return location_type_dict
+
+    @property
+    def location_hierarchy(self):
+        if self._location_hierarchy is None:
+            self._location_hierarchy = self.get_location_hierarchy()
+        return self._location_hierarchy
+
+    def get_location_hierarchy(self):
+        paginator = SimplePaginator('location', self._page_size)
+        paginator.init(None, False, None)
+
+        # Extract every location, its type and its parent
+        location_data = {}
+        for row in self._api_client.iterate('location', paginator,
+                                            {'limit': self._page_size}):
+            location_data[row['resource_uri']] = {
+                'location_id': row['location_id'],
+                'location_type': row['location_type'],
+                'parent': row['parent'] if 'parent' in row else None
+            }
+
+        # Build a map from location resource_uri to a map from
+        # location_type_code to ancestor location id.
+        ancestors = {}        # includes location itself
+        for resource_uri in location_data:
+            loc_uri = resource_uri
+            type_code_to_id = {}
+            while loc_uri is not None:
+                loc_data = location_data[loc_uri]
+                type_code = self.location_types[loc_data['location_type']]['code']
+                type_code_to_id[type_code] = loc_data['location_id']
+                loc_uri = loc_data['parent']
+            ancestors[resource_uri] = type_code_to_id
+        return ancestors
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -199,19 +199,19 @@ def get_expected_locations_results(include_parent):
                 "location_type_code",
                 "location_type_name",
                 "location_type_parent",
-                "hq",
-                "local"
+                "local",
+                "hq"
             ],
             "rows": [
                 ["id1", "2020-04-01 21:57:26", "d1", "eid1",
                  "2020-04-01 21:58:23", "11.2", "ld1", "lid1", "lt1",
                  "-20.5", "n1", None, "ru1", "sc1", True, "hq", "HQ", None,
-                 "lid1", None],
+                 None, "lid1"],
                 ["id2", "2020-04-01 21:58:47", "d2", None,
                  "2020-04-01 21:59:16", "-56.3", "ld2", "lid2", "lt2",
                  "18.7", "n2", ("ru1" if include_parent else None), "ru2",
                  "sc2", False, "local", "Local", "lt1",
-                 ("lid1" if include_parent else None), "lid2"]
+                 "lid2", ("lid1" if include_parent else None)]
             ]
         }
        ]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -44,80 +44,83 @@ def make_args(project='test', username='test', password='test', **kwargs):
     return namespace
 
 
-client = MockCommCareHqClient({
-    'form': [
-        (
-            {'limit': 100, 'order_by': ['server_modified_on', 'received_on']},
-            [
-                {'id': 1, 'form': {'name': 'f1', 'case': {'@case_id': 'c1'}}},
-                {'id': 2, 'form': {'name': 'f2', 'case': {'@case_id': 'c2'}}},
-            ]
-        ),
-    ],
-    'case': [
-        (
-            {'limit': 100, 'order_by': 'server_date_modified'},
-            [
-                {'id': 'case1'},
-                {'id': 'case2'},
-            ]
-        )
-    ],
-    'user': [
-        (
-            {'limit': 100},
-            [
-                {'id': 'id1', 'email': 'em1', 'first_name': 'fn1',
-                 'last_name': 'ln1',
-                 'user_data': {'commcare_location_id': 'loc1',
-                               'commcare_location_ids': ['loc1', 'loc2'],
-                               'commcare_project': 'p1'},
-                 'username': 'u1'},
-                {'id': 'id2', 'default_phone_number': 'pn2', 'email': 'em2',
-                 'first_name': 'fn2', 'last_name': 'ln2',
-                 'resource_uri': 'ru2',
-                 'user_data': {'commcare_location_id': 'loc2',
-                               'commcare_project': 'p2'},
-                 'username': 'u2'}
-            ]
-        )
-    ],
-    'location_type': [
-        (
-            {'get': True},
-            [
-                {'administrative': True, 'code': 'hq', 'domain': 'd1', 'id': 1,
-                 'name': 'HQ', 'parent': None, 'resource_uri': 'lt1',
-                 'shares_cases': False, 'view_descendants': True},
-                {'administrative': False, 'code': 'local', 'domain': 'd1',
-                 'id': 2, 'name': 'Local',
-                 'parent': 'lt1', 'resource_uri': 'lt2',
-                 'shares_cases': True, 'view_descendants': True}
-            ]
-        )
-    ],
-    'location': [
-        (
-            {'limit': 100},
-            [
-                {'id': 'id1', 'created_at': '2020-04-01T21:57:26.403053',
-                 'domain': 'd1', 'external_id': 'eid1',
-                 'last_modified': '2020-04-01T21:58:23.88343',
-                 'latitude': '11.2', 'location_data': 'ld1',
-                 'location_id': 'lid1', 'location_type': 'lt1',
-                 'longitude': '-20.5', 'name': 'n1',
-                 'resource_uri': 'ru1', 'site_code': 'sc1'},
-                {'id': 'id2', 'created_at': '2020-04-01T21:58:47.627371',
-                 'domain': 'd2', 'last_modified': '2020-04-01T21:59:16.018411',
-                 'latitude': '-56.3',
-                 'location_data': 'ld2', 'location_id': 'lid2',
-                 'location_type': 'lt2', 'longitude': '18.7',
-                 'name': 'n2', 'parent': 'ru1',
-                 'resource_uri': 'ru2', 'site_code': 'sc2'}
-            ]
-        )
-    ],
-})
+def mock_hq_client(include_parent):
+    return MockCommCareHqClient({
+        'form': [
+            (
+                {'limit': 100, 'order_by': ['server_modified_on', 'received_on']},
+                [
+                    {'id': 1, 'form': {'name': 'f1', 'case': {'@case_id': 'c1'}},
+                     'metadata': {'userID': 'id1'}},
+                    {'id': 2, 'form': {'name': 'f2', 'case': {'@case_id': 'c2'}},
+                     'metadata': {'userID': 'id2'}},
+                ]
+            ),
+        ],
+        'case': [
+            (
+                {'limit': 100, 'order_by': 'server_date_modified'},
+                [
+                    {'id': 'case1'},
+                    {'id': 'case2'},
+                ]
+            )
+        ],
+        'user': [
+            (
+                {'limit': 100},
+                [
+                    {'id': 'id1', 'email': 'em1', 'first_name': 'fn1',
+                     'last_name': 'ln1',
+                     'user_data': {'commcare_location_id': 'lid1',
+                                   'commcare_location_ids': ['lid1', 'lid2'],
+                                   'commcare_project': 'p1'},
+                     'username': 'u1'},
+                    {'id': 'id2', 'default_phone_number': 'pn2', 'email': 'em2',
+                     'first_name': 'fn2', 'last_name': 'ln2',
+                     'resource_uri': 'ru0',
+                     'user_data': {'commcare_location_id': 'lid2',
+                                   'commcare_project': 'p2'},
+                     'username': 'u2'}
+                ]
+            )
+        ],
+        'location_type': [
+            (
+                {'limit': 100},
+                [
+                    {'administrative': True, 'code': 'hq', 'domain': 'd1', 'id': 1,
+                     'name': 'HQ', 'parent': None, 'resource_uri': 'lt1',
+                     'shares_cases': False, 'view_descendants': True},
+                    {'administrative': False, 'code': 'local', 'domain': 'd1',
+                     'id': 2, 'name': 'Local',
+                     'parent': 'lt1', 'resource_uri': 'lt2',
+                     'shares_cases': True, 'view_descendants': True}
+                ]
+            )
+        ],
+        'location': [
+            (
+                {'limit': 100},
+                [
+                    {'id': 'id1', 'created_at': '2020-04-01T21:57:26.403053',
+                     'domain': 'd1', 'external_id': 'eid1',
+                     'last_modified': '2020-04-01T21:58:23.88343',
+                     'latitude': '11.2', 'location_data': 'ld1',
+                     'location_id': 'lid1', 'location_type': 'lt1',
+                     'longitude': '-20.5', 'name': 'n1',
+                     'resource_uri': 'ru1', 'site_code': 'sc1'},
+                    {'id': 'id2', 'created_at': '2020-04-01T21:58:47.627371',
+                     'domain': 'd2', 'last_modified': '2020-04-01T21:59:16.018411',
+                     'latitude': '-56.3', 'location_data': 'ld2',
+                     'location_id': 'lid2', 'location_type': 'lt2',
+                     'longitude': '18.7', 'name': 'n2',
+                     'parent': 'ru1' if include_parent else None,
+                     'resource_uri': 'ru2', 'site_code': 'sc2'}
+                ]
+            )
+        ],
+    })
 
 EXPECTED_MULTIPLE_TABLES_RESULTS = [
     {
@@ -165,47 +168,53 @@ EXPECTED_USERS_RESULTS = [
             "username"
         ],
         "rows": [
-            ["id1", None, "em1", "fn1", None, "ln1", None, None, "loc1",
-             "loc1,loc2", None, "p1", "u1"],
-            ["id2", "pn2", "em2", "fn2", None, "ln2", None, "ru2", "loc2",
+            ["id1", None, "em1", "fn1", None, "ln1", None, None, "lid1",
+             "lid1,lid2", None, "p1", "u1"],
+            ["id2", "pn2", "em2", "fn2", None, "ln2", None, "ru0", "lid2",
              None, None, "p2", "u2"]
         ]
     }
 ]
 
-EXPECTED_LOCATIONS_RESULTS = [
-    {
-        "name": "commcare_locations",
-        "headings": [
-            "id",
-            "created_at",
-            "domain",
-            "external_id",
-            "last_modified",
-            "latitude",
-            "location_data",
-            "location_id",
-            "location_type",
-            "longitude",
-            "name",
-            "parent",
-            "resource_uri",
-            "site_code",
-            "location_type_administrative",
-            "location_type_code",
-            "location_type_name",
-            "location_type_parent",
-        ],
-        "rows": [
-            ["id1", "2020-04-01 21:57:26", "d1", "eid1",
-             "2020-04-01 21:58:23", '11.2', "ld1", "lid1", "lt1",
-             '-20.5', "n1", None, "ru1", "sc1", True, "hq", "HQ", None],
-            ["id2", "2020-04-01 21:58:47", "d2", None,
-             "2020-04-01 21:59:16", '-56.3', "ld2", "lid2", "lt2",
-             '18.7', "n2", "ru1", "ru2", "sc2", False, 'local', 'Local', 'lt1']
-        ]
-    }
-]
+def get_expected_locations_results(include_parent):
+    return [
+        {
+            "name": "commcare_locations",
+            "headings": [
+                "id",
+                "created_at",
+                "domain",
+                "external_id",
+                "last_modified",
+                "latitude",
+                "location_data",
+                "location_id",
+                "location_type",
+                "longitude",
+                "name",
+                "parent",
+                "resource_uri",
+                "site_code",
+                "location_type_administrative",
+                "location_type_code",
+                "location_type_name",
+                "location_type_parent",
+                "hq",
+                "local"
+            ],
+            "rows": [
+                ["id1", "2020-04-01 21:57:26", "d1", "eid1",
+                 "2020-04-01 21:58:23", "11.2", "ld1", "lid1", "lt1",
+                 "-20.5", "n1", None, "ru1", "sc1", True, "hq", "HQ", None,
+                 "lid1", None],
+                ["id2", "2020-04-01 21:58:47", "d2", None,
+                 "2020-04-01 21:59:16", "-56.3", "ld2", "lid2", "lt2",
+                 "18.7", "n2", ("ru1" if include_parent else None), "ru2",
+                 "sc2", False, "local", "Local", "lt1",
+                 ("lid1" if include_parent else None), "lid2"]
+            ]
+        }
+       ]
 
 
 class TestCli(unittest.TestCase):
@@ -219,7 +228,7 @@ class TestCli(unittest.TestCase):
             assert writer.tables[table['name']] == table
 
 
-    @mock.patch('commcare_export.cli._get_api_client', return_value=client)
+    @mock.patch('commcare_export.cli._get_api_client', return_value=mock_hq_client(True))
     def test_cli(self, mock_client):
         args = make_args(
             query='tests/008_multiple-tables.xlsx',
@@ -227,7 +236,7 @@ class TestCli(unittest.TestCase):
         )
         self._test_cli(args, EXPECTED_MULTIPLE_TABLES_RESULTS)
 
-    @mock.patch('commcare_export.cli._get_api_client', return_value=client)
+    @mock.patch('commcare_export.cli._get_api_client', return_value=mock_hq_client(True))
     def test_cli_just_users(self, mock_client):
         args = make_args(
             output_format='json',
@@ -235,7 +244,7 @@ class TestCli(unittest.TestCase):
         )
         self._test_cli(args, EXPECTED_USERS_RESULTS)
 
-    @mock.patch('commcare_export.cli._get_api_client', return_value=client)
+    @mock.patch('commcare_export.cli._get_api_client', return_value=mock_hq_client(True))
     def test_cli_table_plus_users(self, mock_client):
         args = make_args(
             query='tests/008_multiple-tables.xlsx',
@@ -245,15 +254,23 @@ class TestCli(unittest.TestCase):
         self._test_cli(args, EXPECTED_MULTIPLE_TABLES_RESULTS +
                        EXPECTED_USERS_RESULTS)
 
-    @mock.patch('commcare_export.cli._get_api_client', return_value=client)
+    @mock.patch('commcare_export.cli._get_api_client', return_value=mock_hq_client(True))
     def test_cli_just_locations(self, mock_client):
         args = make_args(
             output_format='json',
             locations=True
         )
-        self._test_cli(args, EXPECTED_LOCATIONS_RESULTS)
+        self._test_cli(args, get_expected_locations_results(True))
 
-    @mock.patch('commcare_export.cli._get_api_client', return_value=client)
+    @mock.patch('commcare_export.cli._get_api_client', return_value=mock_hq_client(False))
+    def test_cli_locations_without_parents(self, mock_client):
+        args = make_args(
+            output_format='json',
+            locations=True
+        )
+        self._test_cli(args, get_expected_locations_results(False))
+
+    @mock.patch('commcare_export.cli._get_api_client', return_value=mock_hq_client(True))
     def test_cli_table_plus_locations(self, mock_client):
         args = make_args(
             query='tests/008_multiple-tables.xlsx',
@@ -261,7 +278,7 @@ class TestCli(unittest.TestCase):
             locations=True
         )
         self._test_cli(args, EXPECTED_MULTIPLE_TABLES_RESULTS +
-                       EXPECTED_LOCATIONS_RESULTS)
+                       get_expected_locations_results(True))
 
 
 @pytest.fixture(scope='class')
@@ -274,7 +291,6 @@ def checkpoint_manager(pg_db_params):
     cm = CheckpointManager(pg_db_params['url'], 'query', '123', 'test', 'hq', poolclass=sqlalchemy.pool.NullPool)
     cm.create_checkpoint_table()
     return cm
-
 
 def _pull_data(writer, checkpoint_manager, query, since, until, batch_size=10):
     args = make_args(


### PR DESCRIPTION
Here is a simplified version of the change to add organizational data to the export tool. It avoids creating views in a database to reduce brittleness in the face of changes.

The features of the simplified version are:
- add commcare_userid to Excel query specs when --with-organization is used.
- add one column to the commcare_locations table for each organization level and populate it with the location_id of a location's ancestor at that level.
- document the typical pattern for joining user, location and form data together in SQL.
