### PR TITLE
increase the default batch size

### DIFF
--- a/commcare_export/cli.py
+++ b/commcare_export/cli.py
@@ -77,7 +77,7 @@ CLI_ARGS = [
         Argument('strict-types', default=False, action='store_true',
                  help="When saving to a SQL database don't allow changing column types once they are created."),
         Argument('missing-value', default=None, help="Value to use when a field is missing from the form / case."),
-        Argument('batch-size', default=100, help="Number of records to process per batch."),
+        Argument('batch-size', default=200, help="Number of records to process per batch."),
         Argument('checkpoint-key', help="Use this key for all checkpoints instead of the query file MD5 hash "
                                         "in order to prevent table rebuilds after a query file has been edited."),
         Argument('users', default=False, action='store_true',

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -27,6 +27,7 @@ except ImportError:
     from itertools import zip_longest
 
 
+DEFAULT_BATCH_SIZE = 200
 
 def make_args(project='test', username='test', password='test', **kwargs):
     kwargs['project'] = project
@@ -49,7 +50,7 @@ def mock_hq_client(include_parent):
     return MockCommCareHqClient({
         'form': [
             (
-                {'limit': 100, 'order_by': ['server_modified_on', 'received_on']},
+                {'limit': DEFAULT_BATCH_SIZE, 'order_by': ['server_modified_on', 'received_on']},
                 [
                     {'id': 1, 'form': {'name': 'f1', 'case': {'@case_id': 'c1'}},
                      'metadata': {'userID': 'id1'}},
@@ -60,7 +61,7 @@ def mock_hq_client(include_parent):
         ],
         'case': [
             (
-                {'limit': 100, 'order_by': 'server_date_modified'},
+                {'limit': DEFAULT_BATCH_SIZE, 'order_by': 'server_date_modified'},
                 [
                     {'id': 'case1'},
                     {'id': 'case2'},
@@ -69,7 +70,7 @@ def mock_hq_client(include_parent):
         ],
         'user': [
             (
-                {'limit': 100},
+                {'limit': DEFAULT_BATCH_SIZE},
                 [
                     {'id': 'id1', 'email': 'em1', 'first_name': 'fn1',
                      'last_name': 'ln1',
@@ -88,7 +89,7 @@ def mock_hq_client(include_parent):
         ],
         'location_type': [
             (
-                {'limit': 100},
+                {'limit': DEFAULT_BATCH_SIZE},
                 [
                     {'administrative': True, 'code': 'hq', 'domain': 'd1', 'id': 1,
                      'name': 'HQ', 'parent': None, 'resource_uri': 'lt1',
@@ -102,7 +103,7 @@ def mock_hq_client(include_parent):
         ],
         'location': [
             (
-                {'limit': 100},
+                {'limit': DEFAULT_BATCH_SIZE},
                 [
                     {'id': 'id1', 'created_at': '2020-04-01T21:57:26.403053',
                      'domain': 'd1', 'external_id': 'eid1',


### PR DESCRIPTION
when there is more than "one batch" of cases with the same timestamp, the importer will loop forever.

The case importer [defaults to submitting cases in chunks of 100](https://github.com/dimagi/commcare-hq/blob/master/corehq/apps/case_importer/do_import.py#L35) which means that if you use the default setting and have done a case import of > 100 cases you can easily run into this.