### PR TITLE
Fix markdown output

### DIFF
--- a/commcare_export/writers.py
+++ b/commcare_export/writers.py
@@ -233,7 +233,7 @@ class StreamingMarkdownTableWriter(TableWriter):
         else:
             row_template = ' | '.join(['{}'] * len(table.headings))
 
-        if table.get('name'):
+        if table.name:
             self.output_stream.write('\n# %s \n\n' % table.name)
 
         self.output_stream.write('| %s |\n' % row_template.format(*table.headings))


### PR DESCRIPTION
When moving to an [explicit table object from dict](https://github.com/dimagi/commcare-export/commit/dc256537084e57951075eb325871fd00900976f1), markdown support got broken. 

Not a big deal, but it's the first thing we tell people to use in the docs, so probably good to get pushed out sooner rather than later.