### PR TITLE
Raise exception on repeated requests with no progress

### DIFF
--- a/commcare_export/cli.py
+++ b/commcare_export/cli.py
@@ -17,7 +17,7 @@ from commcare_export import writers
 from commcare_export.checkpoint import CheckpointManagerProvider
 from commcare_export.misc import default_to_json
 from commcare_export.utils import get_checkpoint_manager
-from commcare_export.commcare_hq_client import CommCareHqClient, LATEST_KNOWN_VERSION
+from commcare_export.commcare_hq_client import CommCareHqClient, LATEST_KNOWN_VERSION, ResourceRepeatException
 from commcare_export.commcare_minilinq import CommCareHqEnv
 from commcare_export.env import BuiltInEnv, JsonPathEnv, EmitterEnv
 from commcare_export.exceptions import LongFieldsException, DataExportException, MissingQueryFileException
@@ -263,6 +263,11 @@ def evaluate_query(env, query):
                 return EXIT_STATUS_ERROR
             else:
                 raise
+        except ResourceRepeatException as e:
+            print('Stopping because the export is stuck')
+            print(e.message)
+            print('Try increasing --batch-size to overcome the error')
+            return EXIT_STATUS_ERROR
         except KeyboardInterrupt:
             print('\nExport aborted', file=sys.stderr)
             return EXIT_STATUS_ERROR

--- a/commcare_export/commcare_hq_client.py
+++ b/commcare_export/commcare_hq_client.py
@@ -53,6 +53,9 @@ class ResourceRepeatException(Exception):
     def __init__(self, message):
         self.message = message
 
+    def __str__(self):
+        return self.message
+
 
 class CommCareHqClient(object):
     """

--- a/tests/test_commcare_hq_client.py
+++ b/tests/test_commcare_hq_client.py
@@ -9,7 +9,7 @@ import simplejson
 import requests
 
 from commcare_export.checkpoint import CheckpointManagerWithSince
-from commcare_export.commcare_hq_client import CommCareHqClient
+from commcare_export.commcare_hq_client import CommCareHqClient, ResourceRepeatException
 from commcare_export.commcare_minilinq import SimplePaginator, DatePaginator, resource_since_params, get_paginator
 
 
@@ -50,6 +50,27 @@ class FakeDateCaseSession(FakeSession):
             return {
                 'meta': { 'next': None, 'offset': 1, 'limit': 1, 'total_count': 2 },
                 'objects': [ {'id': 1, 'foo': 1}, {'id': 2, 'foo': 2} ]
+            }
+
+
+class FakeRepeatedDateCaseSession(FakeSession):
+    # Model the case where there are as many or more cases with the same
+    # server_date_modified than the batch size (2), so the client requests
+    # the same set of cases in a loop.
+    def _get_results(self, params):
+        if not params:
+            return {
+                'meta': {'next': '?offset=1', 'offset': 0, 'limit': 2, 'total_count': 4},
+                'objects': [{'id': 1, 'foo': 1, 'server_date_modified': '2017-01-01T15:36:22Z'},
+                            {'id': 2, 'foo': 2, 'server_date_modified': '2017-01-01T15:36:22Z'}]
+            }
+        else:
+            since_query_param =resource_since_params['case'].start_param
+            assert params[since_query_param] == '2017-01-01T15:36:22'
+            return {
+                'meta': { 'next': '?offset=1', 'offset': 0, 'limit': 2, 'total_count': 4},
+                'objects': [{'id': 1, 'foo': 1, 'server_date_modified': '2017-01-01T15:36:22Z'},
+                            {'id': 2, 'foo': 2, 'server_date_modified': '2017-01-01T15:36:22Z'}]
             }
 
 
@@ -101,6 +122,14 @@ class TestCommCareHqClient(unittest.TestCase):
     def test_iterate_date(self):
         self._test_iterate(FakeDateFormSession(), get_paginator('form'), 3, [1, 2, 3])
         self._test_iterate(FakeDateCaseSession(), get_paginator('case'), 2, [1, 2])
+
+    def test_repeat_limit(self):
+        try:
+            self._test_iterate(FakeRepeatedDateCaseSession(), get_paginator('case', 2), 2, [1, 2])
+        except ResourceRepeatException as e:
+            assert e.message == "Requested resource '/fake/uri' 10 times with same parameters"
+        else:
+            assert False, "Expected exception never happened"
 
 
 class TestDatePaginator(unittest.TestCase):

--- a/tests/test_commcare_hq_client.py
+++ b/tests/test_commcare_hq_client.py
@@ -8,6 +8,8 @@ import simplejson
 
 import requests
 
+import pytest
+
 from commcare_export.checkpoint import CheckpointManagerWithSince
 from commcare_export.commcare_hq_client import CommCareHqClient, ResourceRepeatException
 from commcare_export.commcare_minilinq import SimplePaginator, DatePaginator, resource_since_params, get_paginator
@@ -124,12 +126,9 @@ class TestCommCareHqClient(unittest.TestCase):
         self._test_iterate(FakeDateCaseSession(), get_paginator('case'), 2, [1, 2])
 
     def test_repeat_limit(self):
-        try:
+        with pytest.raises(ResourceRepeatException,
+                           match="Requested resource '/fake/uri' 10 times with same parameters"):
             self._test_iterate(FakeRepeatedDateCaseSession(), get_paginator('case', 2), 2, [1, 2])
-        except ResourceRepeatException as e:
-            assert e.message == "Requested resource '/fake/uri' 10 times with same parameters"
-        else:
-            assert False, "Expected exception never happened"
 
 
 class TestDatePaginator(unittest.TestCase):


### PR DESCRIPTION
Here is one short-term solution to the problem of batches with all the same timestamp - stop and suggest that the user increase the batch size.

Related doc: https://docs.google.com/document/d/1YnS9mN2gxG-OBREoxLNgpWwIJJgIFW-4NU2QznKG0XM/edit?ts=5ede8253#

I asked some questions in email about the alternative solution of checking for repeated results.