### PR TITLE
don't modify params in place

### DIFF
--- a/commcare_export/commcare_hq_client.py
+++ b/commcare_export/commcare_hq_client.py
@@ -1,5 +1,6 @@
 from __future__ import unicode_literals, print_function, absolute_import, division, generators, nested_scopes
 
+import copy
 import logging
 from collections import OrderedDict
 
@@ -138,7 +139,7 @@ class CommCareHqClient(object):
                     raise ResourceRepeatException("Requested resource '{}' {} times with same parameters".format(resource, repeat_counter))
 
                 batch = self.get(resource, params)
-                last_params = params
+                last_params = copy.copy(params)
                 if not total_count or total_count == 'unknown' or fetched >= total_count:
                     total_count = int(batch['meta']['total_count']) if batch['meta']['total_count'] else 'unknown'
                     fetched = 0


### PR DESCRIPTION
https://dimagi-dev.atlassian.net/browse/SAAS-11041

Introduced in https://github.com/dimagi/commcare-export/pull/149/

Because we are modifying the `params` object in place the [equality check](https://github.com/dimagi/commcare-export/pull/149/files#diff-e9b8e26e329e2f147322d44dd1799109R133) was always returning `True`, causing the request to fail after 10 tries.