### PR TITLE
hex2uuid formats UUIDs

### DIFF
--- a/README.md
+++ b/README.md
@@ -387,7 +387,7 @@ List of builtin functions:
 | str2date                     | Convert string to date                                                         |                                  |
 | bool2int                     | Convert boolean to integer (0, 1)                                              |                                  |
 | str2num                      | Parse string as a number                                                       |                                  |
-| hex2uuid                     | Parse a hex UUID, and format it into hyphen-separated groups                   |                                  |
+| format-uuid                  | Parse a hex UUID, and format it into hyphen-separated groups                   |                                  |
 | substr                       | Returns substring indexed by [first arg, second arg), zero-indexed.            | substr(2, 5) of 'abcdef' = 'cde' |
 | selected-at                  | Returns the Nth word in a string. N is zero-indexed.                           | selected-at(3) - return 4th word |
 | selected                     | Returns True if the given word is in the value.                                | selected(fever)                  |

--- a/README.md
+++ b/README.md
@@ -387,6 +387,7 @@ List of builtin functions:
 | str2date                     | Convert string to date                                                         |                                  |
 | bool2int                     | Convert boolean to integer (0, 1)                                              |                                  |
 | str2num                      | Parse string as a number                                                       |                                  |
+| hex2uuid                     | Parse a hex UUID, and format it into hyphen-separated groups                   |                                  |
 | substr                       | Returns substring indexed by [first arg, second arg), zero-indexed.            | substr(2, 5) of 'abcdef' = 'cde' |
 | selected-at                  | Returns the Nth word in a string. N is zero-indexed.                           | selected-at(3) - return 4th word |
 | selected                     | Returns True if the given word is in the value.                                | selected(fever)                  |

--- a/commcare_export/env.py
+++ b/commcare_export/env.py
@@ -2,6 +2,7 @@ from __future__ import unicode_literals, print_function, absolute_import, divisi
 
 import hashlib
 import json
+import uuid
 from datetime import datetime
 import operator
 import pytz
@@ -355,6 +356,26 @@ def json2str(val):
         return
 
 
+@unwrap('val')
+def hex2uuid(val):
+    """
+    Renders a hex UUID in hyphen-separated groups
+
+    >>> hex2uuid('00a3e0194ce1458794c50971dee2de22')
+    '00a3e019-4ce1-4587-94c5-0971dee2de22'
+    >>> hex2uuid(0x00a3e0194ce1458794c50971dee2de22)
+    '00a3e019-4ce1-4587-94c5-0971dee2de22'
+    """
+    if not val:
+        return None
+    if isinstance(val, int):
+        val = hex(val)
+    try:
+        return str(uuid.UUID(val))
+    except ValueError:
+        return None
+
+
 def join(*args):
     args = [unwrap_val(arg)for arg in args]
     try:
@@ -442,6 +463,7 @@ class BuiltInEnv(DictEnv):
             'str2num': str2num,
             'str2date': str2date,
             'json2str': json2str,
+            'hex2uuid': hex2uuid,
             'selected': selected,
             'selected-at': selected_at,
             'count-selected': count_selected,

--- a/commcare_export/env.py
+++ b/commcare_export/env.py
@@ -357,13 +357,13 @@ def json2str(val):
 
 
 @unwrap('val')
-def hex2uuid(val):
+def format_uuid(val):
     """
     Renders a hex UUID in hyphen-separated groups
 
-    >>> hex2uuid('00a3e0194ce1458794c50971dee2de22')
+    >>> format_uuid('00a3e0194ce1458794c50971dee2de22')
     '00a3e019-4ce1-4587-94c5-0971dee2de22'
-    >>> hex2uuid(0x00a3e0194ce1458794c50971dee2de22)
+    >>> format_uuid(0x00a3e0194ce1458794c50971dee2de22)
     '00a3e019-4ce1-4587-94c5-0971dee2de22'
     """
     if not val:
@@ -463,7 +463,7 @@ class BuiltInEnv(DictEnv):
             'str2num': str2num,
             'str2date': str2date,
             'json2str': json2str,
-            'hex2uuid': hex2uuid,
+            'format-uuid': format_uuid,
             'selected': selected,
             'selected-at': selected_at,
             'count-selected': count_selected,

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -1,0 +1,22 @@
+import doctest
+
+from commcare_export.env import hex2uuid
+
+
+class TestHex2UUID:
+    def test_invalid_hex_int(self):
+        assert hex2uuid(0xf00) is None
+
+    def test_invalid_hex_str(self):
+        assert hex2uuid('f00') is None
+
+    def test_uuid(self):
+        assert hex2uuid('00a3e019-4ce1-4587-94c5-0971dee2de22') \
+               == '00a3e019-4ce1-4587-94c5-0971dee2de22'
+
+
+def test_doctests():
+    import commcare_export.env
+
+    results = doctest.testmod(commcare_export.env)
+    assert results.failed == 0

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -1,22 +1,7 @@
 import doctest
-
-from commcare_export.env import hex2uuid
-
-
-class TestHex2UUID:
-    def test_invalid_hex_int(self):
-        assert hex2uuid(0xf00) is None
-
-    def test_invalid_hex_str(self):
-        assert hex2uuid('f00') is None
-
-    def test_uuid(self):
-        assert hex2uuid('00a3e019-4ce1-4587-94c5-0971dee2de22') \
-               == '00a3e019-4ce1-4587-94c5-0971dee2de22'
+import commcare_export.env
 
 
 def test_doctests():
-    import commcare_export.env
-
     results = doctest.testmod(commcare_export.env)
     assert results.failed == 0

--- a/tests/test_minilinq.py
+++ b/tests/test_minilinq.py
@@ -77,6 +77,9 @@ class TestMiniLinq(unittest.TestCase):
         assert Apply(Reference("str2date"), Literal('2015-01-01T18:32:57.001200Z')).eval(env) == datetime(2015, 1, 1, 18, 32, 57)
         assert Apply(Reference("str2date"), Literal(u'日'.encode('utf8'))).eval(env) == None
         assert Apply(Reference("str2date"), Literal(u'日')).eval(env) == None
+        assert Apply(Reference("hex2uuid"), Literal(0xf00)).eval(env) == None
+        assert Apply(Reference("hex2uuid"), Literal('f00')).eval(env) == None
+        assert Apply(Reference("hex2uuid"), Literal('00a3e019-4ce1-4587-94c5-0971dee2de22')).eval(env) == '00a3e019-4ce1-4587-94c5-0971dee2de22'
         assert Apply(Reference("selected-at"), Literal('a b c'), Literal('1')).eval(env) == 'b'
         assert Apply(Reference("selected-at"), Literal(u'a b 日'), Literal('-1')).eval(env) == u'日'
         assert Apply(Reference("selected-at"), Literal('a b c'), Literal('5')).eval(env) is None

--- a/tests/test_minilinq.py
+++ b/tests/test_minilinq.py
@@ -77,9 +77,9 @@ class TestMiniLinq(unittest.TestCase):
         assert Apply(Reference("str2date"), Literal('2015-01-01T18:32:57.001200Z')).eval(env) == datetime(2015, 1, 1, 18, 32, 57)
         assert Apply(Reference("str2date"), Literal(u'日'.encode('utf8'))).eval(env) == None
         assert Apply(Reference("str2date"), Literal(u'日')).eval(env) == None
-        assert Apply(Reference("hex2uuid"), Literal(0xf00)).eval(env) == None
-        assert Apply(Reference("hex2uuid"), Literal('f00')).eval(env) == None
-        assert Apply(Reference("hex2uuid"), Literal('00a3e019-4ce1-4587-94c5-0971dee2de22')).eval(env) == '00a3e019-4ce1-4587-94c5-0971dee2de22'
+        assert Apply(Reference("format-uuid"), Literal(0xf00)).eval(env) == None
+        assert Apply(Reference("format-uuid"), Literal('f00')).eval(env) == None
+        assert Apply(Reference("format-uuid"), Literal('00a3e019-4ce1-4587-94c5-0971dee2de22')).eval(env) == '00a3e019-4ce1-4587-94c5-0971dee2de22'
         assert Apply(Reference("selected-at"), Literal('a b c'), Literal('1')).eval(env) == 'b'
         assert Apply(Reference("selected-at"), Literal(u'a b 日'), Literal('-1')).eval(env) == u'日'
         assert Apply(Reference("selected-at"), Literal('a b c'), Literal('5')).eval(env) is None


### PR DESCRIPTION
This allows UUIDs to be recognized by databases with a UUID data type, like PostgreSQL and SQL Server.

cc @czue 