### PR TITLE
add form_url & case_url functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -394,6 +394,8 @@ List of builtin functions:
 | json2str                     | Convert a JSON object to a string                                              |
 | template                     | Render a string template (not robust)                                          | template({} on {}, state, date)  |
 | attachment_url               | Convert an attachment name into it's download URL                              |                                  |
+| form_url                     | Output the URL to the form view on CommCare HQ                                 |                                  |
+| case_url                     | Output the URL to the case view on CommCare HQ                                 |                                  |
 
 Output Formats
 --------------

--- a/commcare_export/env.py
+++ b/commcare_export/env.py
@@ -385,6 +385,27 @@ def attachment_url(val):
     )
 
 
+@unwrap('val')
+def form_url(val):
+    return _doc_url('form_data')
+
+
+@unwrap('val')
+def case_url(val):
+    return _doc_url('case_data')
+
+
+def _doc_url(url_path):
+    from commcare_export.minilinq import Apply, Reference, Literal
+    return Apply(
+        Reference('template'),
+        Literal('{}/a/{}/reports/'+ url_path + '/{}/'),
+        Reference('commcarehq_base_url'),
+        Reference('$.domain'),
+        Reference('$.id'),
+    )
+
+
 def template(format_template, *args):
     args = [unwrap_val(arg) for arg in args]
     return format_template.format(*args)
@@ -448,6 +469,8 @@ class BuiltInEnv(DictEnv):
             'join': join,
             'default': default,
             'template': template,
+            'form_url': form_url,
+            'case_url': case_url,
             'attachment_url': attachment_url,
             'filter_empty': _not_val,
             'or': _or,

--- a/tests/test_map_format.py
+++ b/tests/test_map_format.py
@@ -19,6 +19,15 @@ class TestMapFormats(unittest.TestCase):
         expected = Apply(Reference('template'), Literal('my name is {}'), Reference('form.question2'))
         assert parse_template('form.question1', 'template(my name is {}, form.question2)') == expected
 
+    def test_parse_template_args_long(self):
+        expected = Apply(
+            Reference('template'),
+            Literal('https://www.commcarehq.org/a/{}/reports/form_data/{}/'),
+            Reference('$.domain'),
+            Reference('$.id'),
+        )
+        assert parse_template('form.id', 'template(https://www.commcarehq.org/a/{}/reports/form_data/{}/, $.domain, $.id)') == expected
+
     def test_parse_template_no_template(self):
         expected = Literal('Error: template function requires the format template: template()')
         assert parse_template('form.question1', 'template()') == expected

--- a/tests/test_minilinq.py
+++ b/tests/test_minilinq.py
@@ -128,6 +128,18 @@ class TestMiniLinq(unittest.TestCase):
         ).eval(env))
         assert result == expected
 
+    def test_form_url(self):
+        env = BuiltInEnv({'commcarehq_base_url': 'https://www.commcarehq.org'}) | JsonPathEnv(
+            {'id': '123', 'domain': 'd1'})
+        expected = 'https://www.commcarehq.org/a/d1/reports/form_data/123/'
+        assert Apply(Reference('form_url'), Reference('id')).eval(env) == expected
+
+    def test_case_url(self):
+        env = BuiltInEnv({'commcarehq_base_url': 'https://www.commcarehq.org'}) | JsonPathEnv(
+            {'id': '123', 'domain': 'd1'})
+        expected = 'https://www.commcarehq.org/a/d1/reports/case_data/123/'
+        assert Apply(Reference('case_url'), Reference('id')).eval(env) == expected
+
     def test_template(self):
         env = BuiltInEnv() | JsonPathEnv({'a': '1', 'b': '2'})
         assert Apply(Reference('template'), Literal('{}.{}'), Reference('a'), Reference('b')).eval(env) == '1.2'


### PR DESCRIPTION
Quick addition based off conversation on slack. It's currently possible to get this with by using the following Map expression `template(https://www.commcarehq.org/a/{}/reports/form_data/{}/, $.domain, $.id)`.

The CommCare Excel export allow adding a `form_link` column which exports the URL to the form. I made these `X_url` to match the `template_url` function but open to changing it `X_link`.

