### PR TITLE
When writing to MS SQL, use special DATETIME2...

### DIFF
--- a/commcare_export/writers.py
+++ b/commcare_export/writers.py
@@ -357,7 +357,10 @@ class SqlTableWriter(SqlMixin, TableWriter):
         if isinstance(val, bool):
             return sqlalchemy.Boolean()
         elif isinstance(val, datetime.datetime):
-            return sqlalchemy.DateTime()
+            if self.is_mssql:
+                return sqlalchemy.dialects.mssql.DATETIME2()
+            else:
+                return sqlalchemy.DateTime()
         elif isinstance(val, datetime.date):
             return sqlalchemy.Date()
 

--- a/tests/test_writers.py
+++ b/tests/test_writers.py
@@ -281,9 +281,8 @@ class TestSQLWriters(object):
             expected['bazzle']['c'] = '0'
         if 'pyodbc' in writer.connection.engine.driver:
             expected['bazzle']['c'] = '0'
-            # couldn't figure out how to make SQL Server convert date to ISO8601
-            # see https://docs.microsoft.com/en-us/sql/t-sql/functions/cast-and-convert-transact-sql?view=sql-server-2017#date-and-time-styles
-            expected['bazzle']['e'] = 'May  1 2014 11:16AM'
+            # MSSQL includes fractional seconds in returned value.
+            expected['bazzle']['e'] = '2014-05-01 11:16:45.0000000'
 
         for id, row in result.items():
             assert id in expected


### PR DESCRIPTION
...type for datetime objects. This avoids problems with the restricted
year range of default datetime type for MS SQL (1753 is oldest year
allowed for that type).