### PR TITLE
Set mssql nvarchar columns to fixed length to allow indexing

### DIFF
--- a/tests/test_writers.py
+++ b/tests/test_writers.py
@@ -320,7 +320,7 @@ class TestSQLWriters(object):
 
     def test_mssql_nvarchar_length(self, writer):
         with writer:
-            if 'mssql' not in writer.connection.engine.driver:
+            if 'odbc' not in writer.connection.engine.driver:
                 return
 
             # Initialize a table with columns where we expect the "some_data"
@@ -354,10 +354,10 @@ class TestSQLWriters(object):
             assert result['some_data'] == ('some_data', 'nvarchar', -1)
             assert result['big_data'] == ('big_data', 'nvarchar', -1)
 
-    def _get_column_lengths(connection, table_name):
+    def _get_column_lengths(self, connection, table_name):
         return {
             row['COLUMN_NAME']: row for row in connection.execute(
                 "SELECT COLUMN_NAME, DATA_TYPE, CHARACTER_MAXIMUM_LENGTH "
                 "FROM INFORMATION_SCHEMA.COLUMNS "
-                "WHERE TABLE_NAME = {};".format(table_name))
+                "WHERE TABLE_NAME = '{}';".format(table_name))
         }


### PR DESCRIPTION
We've had issues where columns are getting created in mssql that can't be indexed because the length is not getting set correctly.

https://dimagi-dev.atlassian.net/browse/SC-988?focusedCommentId=100916&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-100916

This change sets a max length, but then overrides this if any data is bigger than the 900 byte maximum. These resized columns will no longer be able to be indexed, but having indices on large columns seems funny anyway. 
