### PR TITLE
don't evaluate the generator

### DIFF
--- a/commcare_export/minilinq.py
+++ b/commcare_export/minilinq.py
@@ -434,7 +434,7 @@ class Emit(MiniLinq):
         env.emit_table(TableSpec(
             name=self.table,
             headings=[heading.eval(env) for heading in self.headings],
-            rows=list(map(self.coerce_row, rows)),
+            rows=map(self.coerce_row, rows),
             data_types=[lit.v for lit in self.data_types]
         ))
 

--- a/commcare_export/specs.py
+++ b/commcare_export/specs.py
@@ -13,7 +13,6 @@ class TableSpec:
             isinstance(other, TableSpec)
             and other.name == self.name
             and other.headings == self.headings
-            and other.rows == self.rows
             and other.data_types == self.data_types
         )
 
@@ -21,6 +20,5 @@ class TableSpec:
         return {
             'name': self.name,
             'headings': self.headings,
-            'rows': self.rows,
             'data_types': self.data_types,
         }

--- a/commcare_export/writers.py
+++ b/commcare_export/writers.py
@@ -210,9 +210,9 @@ class JValueTableWriter(TableWriter):
         else:
             assert self.tables[table.name].headings == list(table.headings)
 
-        self.tables[table.name].rows.extend(
+        self.tables[table.name].rows = list(self.tables[table.name].rows) + [
             [to_jvalue(v) for v in row] for row in table.rows
-        )
+        ]
 
 
 class StreamingMarkdownTableWriter(TableWriter):


### PR DESCRIPTION
This change https://github.com/dimagi/commcare-export/commit/842ad486cd2ee633fc5b8baeb14f91d1b1f565e6 which came from this comment https://github.com/dimagi/commcare-export/pull/142#discussion_r431918276 results in placing ALL the export data in memory before writing any of it to the output.

To fix that I've remove the code that eagerly evaluates the generator and also remove the rows from the equality check and JSON output of the TableSpec class (they definitely don't belong in either).

This should also fix https://dimagi-dev.atlassian.net/browse/SAAS-11588

Thanks to @bderenzi for noticing the weirdness and working through the debugging with me.