### PR TITLE
support JSON columns in Postgres

### DIFF
--- a/commcare_export/data_types.py
+++ b/commcare_export/data_types.py
@@ -5,12 +5,14 @@ DATA_TYPE_BOOLEAN = 'boolean'
 DATA_TYPE_DATE = 'date'
 DATA_TYPE_DATETIME = 'datetime'
 DATA_TYPE_INTEGER = 'integer'
+DATA_TYPE_JSON = 'json'
 
 DATA_TYPES_TO_SQLALCHEMY_TYPES = {
     DATA_TYPE_BOOLEAN: sqlalchemy.Boolean(),
     DATA_TYPE_DATETIME: sqlalchemy.DateTime(),
     DATA_TYPE_DATE: sqlalchemy.Date(),
     DATA_TYPE_INTEGER: sqlalchemy.Integer(),
+    DATA_TYPE_JSON: sqlalchemy.JSON(),
 }
 
 class UnknownDataType(Exception):

--- a/commcare_export/writers.py
+++ b/commcare_export/writers.py
@@ -417,6 +417,10 @@ class SqlTableWriter(SqlMixin, TableWriter):
 
         # add dialect specific types
         try:
+            compatibility[sqlalchemy.JSON] = (sqlalchemy.dialects.postgresql.json.JSON,)
+        except AttributeError:
+            pass
+        try:
             compatibility[sqlalchemy.Boolean] += (sqlalchemy.dialects.mssql.base.BIT,)
         except AttributeError:
             pass

--- a/tests/test_writers.py
+++ b/tests/test_writers.py
@@ -321,6 +321,8 @@ class TestSQLWriters(object):
             },
         }
         with writer:
+            if not writer.is_postgres:
+                return
             writer.write_table(TableSpec(**{
                 'name': 'foo_with_json',
                 'headings': ['id', 'json_col'],

--- a/tests/test_writers.py
+++ b/tests/test_writers.py
@@ -290,6 +290,62 @@ class TestSQLWriters(object):
             assert dict(row) == expected[id]
 
 
+    def test_json_type(self, strict_writer):
+        complex_object = {
+            'poke1': {
+                'name': 'snorlax',
+                'color': 'blue',
+                'attributes': {
+                    'strength': 10,
+                    'endurance': 10,
+                    'speed': 4,
+                },
+                'friends': [
+                    'pikachu',
+                    'charmander',
+                ],
+            },
+            'poke2': {
+                'name': 'pikachu',
+                'color': 'yellow',
+                'attributes': {
+                    'strength': 2,
+                    'endurance': 2,
+                    'speed': 8,
+                    'cuteness': 10,
+                },
+                'friends': [
+                    'snorlax',
+                    'charmander',
+                ],
+            },
+        }
+        with strict_writer:
+            strict_writer.write_table(TableSpec(**{
+                'name': 'foo_with_json',
+                'headings': ['id', 'json_col'],
+                'rows': [
+                    ['simple', {'k1': 'v1', 'k2': 'v2'}],
+                    ['with_lists', {'l1': ['i1', 'i2']}],
+                    ['complex', complex_object],
+                ],
+                'data_types': [
+                    'text',
+                    'json',
+                ]
+            }))
+
+        # We can use raw SQL instead of SqlAlchemy expressions because we built the DB above
+        with strict_writer:
+            result = dict([(row['id'], row) for row in strict_writer.connection.execute(
+                'SELECT id, json_col FROM foo_with_json'
+            )])
+
+        assert len(result) == 3
+        assert dict(result['simple']) == {'id': 'simple', 'json_col': {'k1': 'v1', 'k2': 'v2'}}
+        assert dict(result['with_lists']) == {'id': 'with_lists', 'json_col': {'l1': ['i1', 'i2']}}
+        assert dict(result['complex']) == {'id': 'complex', 'json_col': complex_object}
+
     def test_explicit_types(self, strict_writer):
         with strict_writer:
             strict_writer.write_table(TableSpec(**{

--- a/tests/test_writers.py
+++ b/tests/test_writers.py
@@ -290,7 +290,7 @@ class TestSQLWriters(object):
             assert dict(row) == expected[id]
 
 
-    def test_json_type(self, strict_writer):
+    def test_json_type(self, writer):
         complex_object = {
             'poke1': {
                 'name': 'snorlax',
@@ -320,8 +320,8 @@ class TestSQLWriters(object):
                 ],
             },
         }
-        with strict_writer:
-            strict_writer.write_table(TableSpec(**{
+        with writer:
+            writer.write_table(TableSpec(**{
                 'name': 'foo_with_json',
                 'headings': ['id', 'json_col'],
                 'rows': [
@@ -336,8 +336,8 @@ class TestSQLWriters(object):
             }))
 
         # We can use raw SQL instead of SqlAlchemy expressions because we built the DB above
-        with strict_writer:
-            result = dict([(row['id'], row) for row in strict_writer.connection.execute(
+        with writer:
+            result = dict([(row['id'], row) for row in writer.connection.execute(
                 'SELECT id, json_col FROM foo_with_json'
             )])
 


### PR DESCRIPTION
This adds support for Postgres JSON column types. This is particularly useful if you want to use the DET to generate a "data lake" by exporting the entire contents of e.g. the "form" property.

I was shocked how easy this was. Only one little quirk to chase down with type compatibility.