### PR TITLE
Change mysql collation and charset from utf8 -> utf8mb4

### DIFF
--- a/commcare_export/cli.py
+++ b/commcare_export/cli.py
@@ -209,6 +209,12 @@ def _get_writer(output_format, output, strict_types):
     elif output_format == 'sql':
         # Output should be a connection URL
         # Writer had bizarre issues so we use a full connection instead of passing in a URL or engine
+        if output.startswith('mysql'):
+            charset_split = output.split('charset=')
+            if len(charset_split) > 1 and charset_split[1] != 'utf8mb4':
+                raise Exception(f"The charset '{charset_split[1]}' might cause problems with the export. "
+                                f"It is recommended that you use 'utf8mb4' instead.")
+
         return writers.SqlTableWriter(output, strict_types)
     else:
         raise Exception("Unknown output format: {}".format(output_format))

--- a/commcare_export/writers.py
+++ b/commcare_export/writers.py
@@ -262,7 +262,7 @@ class SqlMixin(object):
 
     def __init__(self, db_url, poolclass=None, engine=None):
         self.db_url = db_url
-        self.collation = 'utf8_bin' if 'mysql' in db_url else None
+        self.collation = 'utf8mb4_unicode_ci' if 'mysql' in db_url else None
         self.engine = engine or sqlalchemy.create_engine(db_url, poolclass=poolclass)
 
     def __enter__(self):

--- a/commcare_export/writers.py
+++ b/commcare_export/writers.py
@@ -262,7 +262,7 @@ class SqlMixin(object):
 
     def __init__(self, db_url, poolclass=None, engine=None):
         self.db_url = db_url
-        self.collation = 'utf8mb4_unicode_ci' if 'mysql' in db_url else None
+        self.collation = 'utf8_bin' if 'mysql' in db_url else None
         self.engine = engine or sqlalchemy.create_engine(db_url, poolclass=poolclass)
 
     def __enter__(self):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -66,7 +66,7 @@ mssql_base = os.environ.get('MSSQL_URL', 'mssql+pyodbc://SA:Password@123@localho
         'admin_db': 'postgres'
     }, marks=pytest.mark.postgres),
     pytest.param({
-        'url': '{}%s?charset=utf8'.format(mysql_base),
+        'url': '{}%s?charset=utf8mb4'.format(mysql_base),
     }, marks=pytest.mark.mysql),
     pytest.param({
         'url': '{}%s?driver=ODBC+Driver+17+for+SQL+Server'.format(mssql_base),

--- a/tests/test_writers.py
+++ b/tests/test_writers.py
@@ -439,6 +439,16 @@ class TestSQLWriters(object):
             result = self._get_column_lengths(writer.connection, 'mssql_nvarchar_length_downsize')
             assert result['some_data'] == ('some_data', 'nvarchar', -1)
 
+    def test_big_lump_of_poo(self, writer):
+        with writer:
+            writer.write_table(TableSpec(**{
+                'name': 'foo_with_emoji',
+                'headings': ['id', 'fun_to_be_had'],
+                'rows': [
+                    ['A steaming poo', '💩'],
+                    ['2020', '😷'],
+                ],
+            }))
 
     def _get_column_lengths(self, connection, table_name):
         return {


### PR DESCRIPTION
The test passes locally with my changes, but for some reason I'm inclined to feel that this PR still needs a migration to alter the existing MySQL columns' CHARACTER SET and COLLATION settings to `utf8mb4` and `utf8mb4_unicode_ci` respectively...or is my hunch wrong?

See [ticket](https://dimagi-dev.atlassian.net/browse/SC-1315)