### PR TITLE
remove additional auto-id field

### DIFF
--- a/commcare_export/env.py
+++ b/commcare_export/env.py
@@ -200,10 +200,6 @@ class JsonPathEnv(Env):
 
         def iter(jsonpath_expr=jsonpath_expr): # Capture closure
             for datum in jsonpath_expr.find(self.__bindings):
-                # HACK: The auto id from jsonpath_rw is good, but we lose it when we do .value here,
-                # so just slap it on if not present
-                if isinstance(datum.value, dict) and 'id' not in datum.value:
-                    datum.value['id'] = jsonpath.AutoIdForDatum(datum).value
                 yield datum
         return RepeatableIterator(iter)
 

--- a/tests/test_minilinq.py
+++ b/tests/test_minilinq.py
@@ -72,15 +72,11 @@ class TestMiniLinq(unittest.TestCase):
             Reference("id"), Reference('baz'), Reference('$.id'), Reference('$.foo.id'), Reference('$.foo.name')
         ]))
         self.check_case(mmap.eval(env), [
-            ['1.bar.1.bar.[0]', 'a1', '1', '1.bid', 'bob'],
+            ['1.bar.[0]', 'a1', '1', '1.bid', 'bob'],
             ['1.bar.bazzer', 'a2', '1', '1.bid', 'bob']
         ])
 
-        # Without the additional auto id field added in JsonPathEnv the result for Reference("id") changes
-        # as follows:
-        #   '1.bar.1.bar.[0]' -> '1.bar.[0]'
-
-        # With the change above AND a change to jsonpath_rw to prevent converting IDs that exist into
+        # With a change to jsonpath_rw to prevent converting IDs that exist into
         # auto IDs (see https://github.com/kennknowles/python-jsonpath-rw/pull/96) we get the following:
         #   Reference("id"):
         #       '1.bar.bazzer' -> 'bazzer'


### PR DESCRIPTION
I believe this 'hack' become unecessary after this change [e1eae02417dbaeaf34c407bef0afe9600a21e24a](https://github.com/dimagi/commcare-export/commit/e1eae02417dbaeaf34c407bef0afe9600a21e24a).

Unfortunately this change may break existing usages of the DET if the 'auto_id' functionality is being used. This would be limited to a reference to an `id` field other than the root ID: `$.id` (or just `id` if not referencing a nested object).