### PR TITLE
Ability to emit the root document if the desired sub-document does not exist

### DIFF
--- a/commcare_export/cli.py
+++ b/commcare_export/cli.py
@@ -91,6 +91,9 @@ CLI_ARGS = [
                  help="Export tables containing mobile worker data and "
                       "location data and add a commcare_userid field to any "
                       "exported form or case"),
+        Argument('export-root-if-no-subdocument', default=False, action='store_true', help=(
+            "Use this when you are exporting a nested document e.g. form.form..case, messaging-event.messages.[*]"
+            "And you want to have a record exported even if the nested document does not exist or is empty."))
     ]
 
 
@@ -154,18 +157,22 @@ def _get_query(args, writer, column_enforcer=None):
         writer.supports_multi_table_write,
         writer.max_column_length,
         writer.required_columns,
-        column_enforcer
+        column_enforcer,
+        args.export_root_if_no_subdocument
     )
 
+
 def _get_query_from_file(query_arg, missing_value, combine_emits,
-                         max_column_length, required_columns, column_enforcer):
+                         max_column_length, required_columns, column_enforcer,
+                         value_or_root):
     if os.path.exists(query_arg):
         if os.path.splitext(query_arg)[1] in ['.xls', '.xlsx']:
             import openpyxl
             workbook = openpyxl.load_workbook(query_arg)
             return excel_query.get_queries_from_excel(
                 workbook, missing_value, combine_emits,
-                max_column_length, required_columns, column_enforcer
+                max_column_length, required_columns, column_enforcer,
+                value_or_root
             )
         else:
             with io.open(query_arg, encoding='utf-8') as fh:

--- a/commcare_export/cli.py
+++ b/commcare_export/cli.py
@@ -93,7 +93,7 @@ CLI_ARGS = [
                       "exported form or case"),
         Argument('export-root-if-no-subdocument', default=False, action='store_true', help=(
             "Use this when you are exporting a nested document e.g. form.form..case, messaging-event.messages.[*]"
-            "And you want to have a record exported even if the nested document does not exist or is empty."))
+            " And you want to have a record exported even if the nested document does not exist or is empty."))
     ]
 
 

--- a/commcare_export/env.py
+++ b/commcare_export/env.py
@@ -433,7 +433,20 @@ def template(format_template, *args):
 
 
 def _or(*args):
-    unwrapped_args = (unwrap_val(arg) for arg in args)
+    return _or_impl(unwrap_val, *args)
+
+
+def _or_raw(*args):
+    def unwrap_iter(arg):
+        if isinstance(arg, RepeatableIterator):
+            return list(arg)
+        return arg
+
+    return _or_impl(unwrap_iter, *args)
+
+
+def _or_impl(_unwrap, *args):
+    unwrapped_args = (_unwrap(arg) for arg in args)
     vals = (val for val in unwrapped_args if val is not None and val != [])
     try:
         return next(vals)
@@ -498,6 +511,7 @@ class BuiltInEnv(DictEnv):
             'or': _or,
             'sha1': sha1,
             'substr': substr,
+            '_or_raw': _or_raw,  # for internal use
         })
         return super(BuiltInEnv, self).__init__(d)
 

--- a/commcare_export/env.py
+++ b/commcare_export/env.py
@@ -11,6 +11,8 @@ from itertools import chain
 
 from jsonpath_rw import jsonpath
 from jsonpath_rw.parser import parse as parse_jsonpath
+
+from commcare_export.jsonpath_utils import split_leftmost
 from commcare_export.misc import unwrap, unwrap_val
 
 from commcare_export.repeatable_iterator import RepeatableIterator
@@ -179,7 +181,8 @@ class JsonPathEnv(Env):
     """
     def __init__(self, bindings=None):
         self.__bindings = bindings or {}
-        
+        self.__restrict_to_root = bool(jsonpath.Fields("__root_only").find(self.__bindings))
+
         # Currently hardcoded because it is a global is jsonpath-rw
         # Probably not widely used, but will require refactor if so
         jsonpath.auto_id_field = "id"
@@ -198,14 +201,19 @@ class JsonPathEnv(Env):
         else:
             raise NotFound(unwrap_val(name))
 
-        def iter(jsonpath_expr=jsonpath_expr): # Capture closure
+        if self.__restrict_to_root and str(jsonpath_expr) != 'id':  # special case for 'id'
+            expr, _ = split_leftmost(jsonpath_expr)
+            if not isinstance(expr, jsonpath.Root):
+                return RepeatableIterator(lambda : iter(()))
+
+        def iterator(jsonpath_expr=jsonpath_expr): # Capture closure
             for datum in jsonpath_expr.find(self.__bindings):
                 # HACK: The auto id from jsonpath_rw is good, but we lose it when we do .value here,
                 # so just slap it on if not present
                 if isinstance(datum.value, dict) and 'id' not in datum.value:
                     datum.value['id'] = jsonpath.AutoIdForDatum(datum).value
                 yield datum
-        return RepeatableIterator(iter)
+        return RepeatableIterator(iterator)
 
     def bind(self, *args):
         "(str, ??) -> Env | ({str: ??}) -> Env"

--- a/commcare_export/excel_query.py
+++ b/commcare_export/excel_query.py
@@ -252,7 +252,7 @@ def compile_source(worksheet, value_or_root=False):
         return data_source, api_query, None
     else:
         if value_or_root:
-            # if the jsonpath doesn't not yield a value yield the root document
+            # if the jsonpath doesn't yield a value yield the root document
             expr = get_value_or_root_expression(data_source_jsonpath)
         else:
             expr = Reference(str(data_source_jsonpath))

--- a/commcare_export/jsonpath_utils.py
+++ b/commcare_export/jsonpath_utils.py
@@ -1,0 +1,12 @@
+from jsonpath_rw import jsonpath
+
+
+def split_leftmost(jsonpath_expr):
+    if isinstance(jsonpath_expr, jsonpath.Child):
+        further_leftmost, rest = split_leftmost(jsonpath_expr.left)
+        return further_leftmost, rest.child(jsonpath_expr.right)
+    elif isinstance(jsonpath_expr, jsonpath.Descendants):
+        further_leftmost, rest = split_leftmost(jsonpath_expr.left)
+        return further_leftmost, jsonpath.Descendants(rest, jsonpath_expr.right)
+    else:
+        return jsonpath_expr, jsonpath.This()

--- a/tests/test_excel_query.py
+++ b/tests/test_excel_query.py
@@ -412,7 +412,7 @@ class TestExcelQuery(unittest.TestCase):
             )
         ])
 
-        self._compare_minilinq_to_compiled(minilinq, '008_multiple-tables.xlsx', combine=True)
+        self._compare_minilinq_to_compiled(minilinq, '008_multiple-tables.xlsx', combine_emits=True)
 
     def test_multi_emit_no_combine(self):
         minilinq = List([
@@ -461,7 +461,7 @@ class TestExcelQuery(unittest.TestCase):
             )
         ])
 
-        self._compare_minilinq_to_compiled(minilinq, '008_multiple-tables.xlsx', combine=False)
+        self._compare_minilinq_to_compiled(minilinq, '008_multiple-tables.xlsx', combine_emits=False)
 
     def test_multi_emit_with_organization(self):
         minilinq = List([
@@ -522,11 +522,63 @@ class TestExcelQuery(unittest.TestCase):
         ])
 
         column_enforcer = ColumnEnforcer()
-        self._compare_minilinq_to_compiled(minilinq, '008_multiple-tables.xlsx', combine=True,
+        self._compare_minilinq_to_compiled(minilinq, '008_multiple-tables.xlsx', combine_emits=True,
                                            column_enforcer=column_enforcer)
 
-    def _compare_minilinq_to_compiled(self, minilinq, filename, combine=False, column_enforcer=None):
+    def test_value_or_root(self):
+        minilinq = List([
+            Bind("checkpoint_manager",
+                 Apply(Reference('get_checkpoint_manager'), Literal("form"), Literal(["Forms"])),
+                 Emit(
+                     table="Forms",
+                     headings=[Literal("id"), Literal("name")],
+                     missing_value='---',
+                     source=Map(
+                         source=Apply(Reference("api_data"), Literal("form"), Reference('checkpoint_manager')),
+                         body=List([
+                             Reference("id"),
+                             Reference("form.name"),
+                         ]),
+                     )
+                 )
+                 ),
+            Bind("checkpoint_manager",
+                 Apply(Reference('get_checkpoint_manager'), Literal("form"), Literal(["Cases"])),
+                 Emit(
+                     table="Cases",
+                     headings=[Literal("case_id")],
+                     missing_value='---',
+                     source=Map(
+                         source=FlatMap(
+                             body=Apply(Reference("_or_raw"), Reference("form..case"), Reference("$")),
+                             source=Apply(Reference("api_data"), Literal("form"), Reference('checkpoint_manager'))
+                         ),
+                         body=List([
+                             Reference("@case_id"),
+                         ]),
+                     )
+                 )
+                 ),
+            Bind("checkpoint_manager",
+                 Apply(Reference('get_checkpoint_manager'), Literal("case"), Literal(["Other cases"])),
+                 Emit(
+                     table="Other cases",
+                     headings=[Literal("id")],
+                     missing_value='---',
+                     source=Map(
+                         source=Apply(Reference("api_data"), Literal("case"), Reference('checkpoint_manager')),
+                         body=List([
+                             Reference("id")
+                         ])
+                     )
+                 )
+                 )
+        ])
+
+        self._compare_minilinq_to_compiled(minilinq, '008_multiple-tables.xlsx', combine_emits=False, value_or_root=True)
+
+    def _compare_minilinq_to_compiled(self, minilinq, filename, **kwargs):
         print("Parsing {}".format(filename))
         abs_path = os.path.join(os.path.dirname(__file__), filename)
-        compiled = get_queries_from_excel(openpyxl.load_workbook(abs_path), missing_value='---', combine_emits=combine, column_enforcer=column_enforcer)
+        compiled = get_queries_from_excel(openpyxl.load_workbook(abs_path), missing_value='---', **kwargs)
         assert compiled.to_jvalue() == minilinq.to_jvalue(), filename

--- a/tests/test_excel_query.py
+++ b/tests/test_excel_query.py
@@ -550,7 +550,11 @@ class TestExcelQuery(unittest.TestCase):
                      missing_value='---',
                      source=Map(
                          source=FlatMap(
-                             body=Apply(Reference("_or_raw"), Reference("form..case"), Reference("$")),
+                             body=Apply(
+                                 Reference("_or_raw"),
+                                 Reference("form..case"),
+                                 Bind("__root_only", Literal(True), Reference("$"))
+                             ),
                              source=Apply(Reference("api_data"), Literal("form"), Reference('checkpoint_manager'))
                          ),
                          body=List([

--- a/tests/test_minilinq.py
+++ b/tests/test_minilinq.py
@@ -96,6 +96,7 @@ class TestMiniLinq(unittest.TestCase):
             {"id": 3, "foo": {'id': 'bid', 'name': 'mip'}, "bar": {}},
             # {"id": 4, "foo": {'id': 'bid', 'name': 'map'}, "bar": None},  # fails with TypeError from jsonpath
             {"id": 5, "foo": {'id': 'bid', 'name': 'mop'}},
+            {"id": 6, "foo": {'id': 'bid', 'name': 'mop'}, "baz": "root_bazz"},
         ]
         value_or_root = get_value_or_root_expression('bar.[*]')
         flatmap = FlatMap(source=Literal(data), body=value_or_root)
@@ -109,6 +110,7 @@ class TestMiniLinq(unittest.TestCase):
             ['3.bar.3.bar.[0]', [], '3', '3.bid', 'mip'],
             # ['4.bar.[0]', [], '4', '4.bid', 'map'],
             ['5', [], '5', '5.bid', 'mop'],
+            ['6', [], '6', '6.bid', 'mop'],
         ])
 
     def test_eval_collapsed_list(self):

--- a/tests/test_minilinq.py
+++ b/tests/test_minilinq.py
@@ -7,6 +7,7 @@ import pytest
 from six.moves import xrange
 
 from commcare_export.env import *
+from commcare_export.excel_query import get_value_or_root_expression
 from commcare_export.minilinq import *
 from commcare_export.writers import JValueTableWriter
 
@@ -96,9 +97,7 @@ class TestMiniLinq(unittest.TestCase):
             # {"id": 4, "foo": {'id': 'bid', 'name': 'map'}, "bar": None},  # fails with TypeError from jsonpath
             {"id": 5, "foo": {'id': 'bid', 'name': 'mop'}},
         ]
-        value_or_root = Apply(
-            Reference('_or_raw'), Reference(str('bar.[*]')), Reference("$")
-        )
+        value_or_root = get_value_or_root_expression('bar.[*]')
         flatmap = FlatMap(source=Literal(data), body=value_or_root)
         mmap = Map(source=flatmap, body=List([
             Reference("id"), Reference('baz'), Reference('$.id'), Reference('$.foo.id'), Reference('$.foo.name')


### PR DESCRIPTION
The focus of the changes here is to allow exporting data from the messaging event API even when there are no messages. Each event may have multiple messages so in order to get one row per message we need an expression like this:
```
messaging-event.messages.[*]
```

However if there are no messages, as is the case when the event errors, we still want to export one row for the event. To accomplish this a new command line option is added to the CLI:

```
--export-root-if-no-subdocument
    Use this when you are exporting a nested document e.g. form.form..case, messaging-event.messages.[*]
    And you want to have a record exported even if the nested document does not exist or is empty.
```

When this option is used in conjunction with a Data Source query like those given in the examples, the minilnq expression
is adjusted so that if the main expression returns no results, the root document is used instead:

```diff
- Reference('messages.[*]')
+ Apply(Reference('_or_raw'), Reference('messages.[*]'), Reference("$"))
```

The `_or_raw` function is similar to `or` but it does not fully unwrap the values.