### PR TITLE
switch to jsonpath-ng

### DIFF
--- a/commcare_export/env.py
+++ b/commcare_export/env.py
@@ -9,8 +9,8 @@ import pytz
 import six
 from itertools import chain
 
-from jsonpath_rw import jsonpath
-from jsonpath_rw.parser import parse as parse_jsonpath
+from jsonpath_ng import jsonpath
+from jsonpath_ng.parser import parse as parse_jsonpath
 
 from commcare_export.jsonpath_utils import split_leftmost
 from commcare_export.misc import unwrap, unwrap_val
@@ -183,7 +183,7 @@ class JsonPathEnv(Env):
         self.__bindings = bindings or {}
         self.__restrict_to_root = bool(jsonpath.Fields("__root_only").find(self.__bindings))
 
-        # Currently hardcoded because it is a global is jsonpath-rw
+        # Currently hardcoded because it is a global is jsonpath-ng
         # Probably not widely used, but will require refactor if so
         jsonpath.auto_id_field = "id"
 
@@ -208,7 +208,7 @@ class JsonPathEnv(Env):
 
         def iterator(jsonpath_expr=jsonpath_expr): # Capture closure
             for datum in jsonpath_expr.find(self.__bindings):
-                # HACK: The auto id from jsonpath_rw is good, but we lose it when we do .value here,
+                # HACK: The auto id from jsonpath_ng is good, but we lose it when we do .value here,
                 # so just slap it on if not present
                 if isinstance(datum.value, dict) and 'id' not in datum.value:
                     datum.value['id'] = jsonpath.AutoIdForDatum(datum).value

--- a/commcare_export/excel_query.py
+++ b/commcare_export/excel_query.py
@@ -2,11 +2,11 @@ from __future__ import unicode_literals, print_function, absolute_import, divisi
 import re
 from collections import defaultdict, namedtuple
 
-from jsonpath_rw.lexer import JsonPathLexerError
+from jsonpath_ng.lexer import JsonPathLexerError
 from six.moves import xrange
 
-from jsonpath_rw import jsonpath
-from jsonpath_rw.parser import parse as parse_jsonpath
+from jsonpath_ng import jsonpath
+from jsonpath_ng.parser import parse as parse_jsonpath
 
 from commcare_export.exceptions import LongFieldsException, MissingColumnException, ReservedTableNameException
 from commcare_export.jsonpath_utils import split_leftmost

--- a/commcare_export/jsonpath_utils.py
+++ b/commcare_export/jsonpath_utils.py
@@ -1,4 +1,4 @@
-from jsonpath_rw import jsonpath
+from jsonpath_ng import jsonpath
 
 
 def split_leftmost(jsonpath_expr):

--- a/commcare_export/misc.py
+++ b/commcare_export/misc.py
@@ -3,7 +3,7 @@ import functools
 import hashlib
 import inspect
 import io
-from jsonpath_rw import jsonpath
+from jsonpath_ng import jsonpath
 from commcare_export.repeatable_iterator import RepeatableIterator
 
 

--- a/setup.py
+++ b/setup.py
@@ -69,7 +69,7 @@ setuptools.setup(
     install_requires = [
         'alembic',
         'argparse',
-        'jsonpath-rw>=1.2.1',
+        'jsonpath-ng~=1.5',
         'openpyxl==2.5.12',
         'python-dateutil',
         'requests',

--- a/tests/test_commcare_minilinq.py
+++ b/tests/test_commcare_minilinq.py
@@ -1,7 +1,7 @@
 import unittest
 from itertools import *
 
-from jsonpath_rw import jsonpath
+from jsonpath_ng import jsonpath
 
 from commcare_export.checkpoint import CheckpointManagerWithDetails
 from commcare_export.minilinq import *

--- a/tests/test_minilinq.py
+++ b/tests/test_minilinq.py
@@ -118,10 +118,9 @@ class TestMiniLinq(unittest.TestCase):
             "bar": {},
         }
         self._test_value_or_root([Reference('id'), Reference('baz'), Reference('$.foo')], data, [
-            ['1.bar.1.bar.[0]', [], "I am foo"],  # weird ID here due to bug in jsonpath
+            ['1', [], "I am foo"],
         ])
 
-    @pytest.mark.skip(reason="fails with TypeError from jsonpath")
     def test_value_or_root_None(self):
         """Should use the root object if the child is None"""
         data = {
@@ -129,7 +128,7 @@ class TestMiniLinq(unittest.TestCase):
             "bar": None,
         }
         self._test_value_or_root([Reference('id'), Reference('baz')], data, [
-            ['1.bar.[0]', []],  # weird ID here due to bug in jsonpath
+            ['1', []],
         ])
 
     def test_value_or_root_missing(self):

--- a/tests/test_minilinq.py
+++ b/tests/test_minilinq.py
@@ -45,7 +45,7 @@ class TestMiniLinq(unittest.TestCase):
         self.check_case(Reference("foo.$.baz").eval(JsonPathEnv({'foo': [2], 'baz': 3})), [3])
 
     def test_eval_auto_id_reference(self):
-        "Test that we have turned on the jsonpath_rw.jsonpath.auto_id field properly"
+        "Test that we have turned on the jsonpath_ng.jsonpath.auto_id field properly"
         env = BuiltInEnv()
 
         self.check_case(Reference("foo.id").eval(JsonPathEnv({'foo': [2]})), ['foo'])
@@ -55,7 +55,7 @@ class TestMiniLinq(unittest.TestCase):
 
     def test_eval_auto_id_reference_nested(self):
         # this test is documentation of existing (weird) functionality
-        # that results from a combination of jsonpath_rw auto_id feature and
+        # that results from a combination of jsonpath_ng auto_id feature and
         # JsonPathEnv.lookup (which adds an additional auto ID for some reason).
         env = JsonPathEnv({})
 
@@ -78,7 +78,7 @@ class TestMiniLinq(unittest.TestCase):
         # as follows:
         #   '1.bar.1.bar.[0]' -> '1.bar.[0]'
 
-        # With the change above AND a change to jsonpath_rw to prevent converting IDs that exist into
+        # With the change above AND a change to jsonpath_ng to prevent converting IDs that exist into
         # auto IDs (see https://github.com/kennknowles/python-jsonpath-rw/pull/96) we get the following:
         #   Reference("id"):
         #       '1.bar.bazzer' -> 'bazzer'


### PR DESCRIPTION
PR on top of https://github.com/dimagi/commcare-export/pull/189

jsonpath-ng is a fork of jsonpath-rw with some additional features and a number of bugfixes. Since jsonpath-rw is not currently maintained it makes sense to move to jsonpath-ng. jsonpath-ng is also used in HQ.