### PR TITLE
add unique function for removing duplicate values when exporting lists

### DIFF
--- a/commcare_export/env.py
+++ b/commcare_export/env.py
@@ -475,6 +475,13 @@ def substr(val, start, end):
     return val[start:end]
 
 
+@unwrap('val')
+def unique(val):
+    if isinstance(val, list):
+        return list(set(val))
+    return val
+
+
 class BuiltInEnv(DictEnv):
     """
     A built-in environment of operators and functions
@@ -519,7 +526,8 @@ class BuiltInEnv(DictEnv):
             'or': _or,
             'sha1': sha1,
             'substr': substr,
-            '_or_raw': _or_raw,  # for internal use
+            '_or_raw': _or_raw,  # for internal use,
+            'unique': unique
         })
         return super(BuiltInEnv, self).__init__(d)
 

--- a/tests/test_minilinq.py
+++ b/tests/test_minilinq.py
@@ -261,6 +261,11 @@ class TestMiniLinq(unittest.TestCase):
         expected = 'https://www.commcarehq.org/a/d1/reports/case_data/123/'
         assert Apply(Reference('case_url'), Reference('id')).eval(env) == expected
 
+    def test_unique(self):
+        env = BuiltInEnv() | JsonPathEnv(
+            {"list": [{"a": 1}, {"a": 2}, {"a": 3}, {"a": 2}]})
+        assert Apply(Reference('unique'), Reference('list[*].a')).eval(env) == [1, 2, 3]
+
     def test_template(self):
         env = BuiltInEnv() | JsonPathEnv({'a': '1', 'b': '2'})
         assert Apply(Reference('template'), Literal('{}.{}'), Reference('a'), Reference('b')).eval(env) == '1.2'


### PR DESCRIPTION
This is useful for the messaging API:

Data Source: `messaging-event`
Source field: `messages[*].phone_number`
Value without unique: `+16199555086,+16199555086,+16199555086,+16199555086`
Value with unique: `+16199555086`
