### PR TITLE
FIX: Alembic 1.7.x is breaking migrations

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,7 @@ setuptools.setup(
     include_package_data=True,
     license = 'MIT',
     install_requires = [
-        'alembic<=1.6.5',
+        'alembic<1.7',
         'argparse',
         'jsonpath-ng~=1.5',
         'openpyxl==2.5.12',

--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,7 @@ setuptools.setup(
     include_package_data=True,
     license = 'MIT',
     install_requires = [
-        'alembic',
+        'alembic==1.6.5',
         'argparse',
         'jsonpath-ng~=1.5',
         'openpyxl==2.5.12',

--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,7 @@ setuptools.setup(
     include_package_data=True,
     license = 'MIT',
     install_requires = [
-        'alembic==1.6.5',
+        'alembic<=1.6.5',
         'argparse',
         'jsonpath-ng~=1.5',
         'openpyxl==2.5.12',


### PR DESCRIPTION
I assume there's some step after this about cutting a new release of the DET, but not sure how to do that.