### PR TITLE
Add DATA_TYPE_TEXT to DATA_TYPES_TO_SQLALCHEMY_TYPES

### DIFF
--- a/commcare_export/data_types.py
+++ b/commcare_export/data_types.py
@@ -8,6 +8,7 @@ DATA_TYPE_INTEGER = 'integer'
 DATA_TYPE_JSON = 'json'
 
 DATA_TYPES_TO_SQLALCHEMY_TYPES = {
+    DATA_TYPE_TEXT: sqlalchemy.Text(),
     DATA_TYPE_BOOLEAN: sqlalchemy.Boolean(),
     DATA_TYPE_DATETIME: sqlalchemy.DateTime(),
     DATA_TYPE_DATE: sqlalchemy.Date(),


### PR DESCRIPTION
As I was testing out the DET configuration with `--strict-types`, type `text` could not be recognised. Turns out `DATA_TYPES_TO_SQLALCHEMY_TYPES` did not have a key-value pair for `DATA_TYPE_TEXT`.