### PR TITLE
Fix import for Alembic>=1.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: python
 sudo: required
-dist: "xenial"
+dist: "bionic"
 python:
  - "3.6"
  - "3.7"
@@ -19,7 +19,7 @@ before_install:
  - docker pull mcr.microsoft.com/mssql/server:2017-latest
  - docker run -e "ACCEPT_EULA=Y" -e "MSSQL_SA_PASSWORD=$MSSQL_SA_PASSWORD" -p 1433:1433 --name mssql1 -d mcr.microsoft.com/mssql/server:2017-latest
  - curl https://packages.microsoft.com/keys/microsoft.asc | sudo apt-key add -
- - echo "deb [arch=amd64] https://packages.microsoft.com/ubuntu/14.04/prod trusty main" | sudo tee /etc/apt/sources.list.d/mssql-release.list
+ - curl https://packages.microsoft.com/config/ubuntu/$(lsb_release -rs)/prod.list | sudo tee /etc/apt/sources.list.d/mssql-release.list
  - sudo apt-get update -qq
 install:
  - sudo apt-get install pandoc

--- a/commcare_export/writers.py
+++ b/commcare_export/writers.py
@@ -4,7 +4,8 @@ import logging
 import zipfile
 from six.moves import zip_longest
 
-import alembic
+from alembic.migration import MigrationContext
+from alembic.operations import Operations
 import csv342 as csv
 import six
 import sqlalchemy
@@ -453,8 +454,8 @@ class SqlTableWriter(SqlMixin, TableWriter):
         return sqlalchemy.UnicodeText(collation=self.collation)
 
     def make_table_compatible(self, table_name, row_dict, data_type_dict):
-        ctx = alembic.migration.MigrationContext.configure(self.connection)
-        op = alembic.operations.Operations(ctx)
+        ctx = MigrationContext.configure(self.connection)
+        op = Operations(ctx)
 
         if not table_name in self.metadata.tables:
             if self.strict_types:

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ class PyTest(TestCommand):
 
 
 test_deps = ['pytest', 'psycopg2', 'mock']
-base_sql_deps = ["SQLAlchemy", "alembic<1.7"]
+base_sql_deps = ["SQLAlchemy", "alembic"]
 postgres = ["psycopg2"]
 mysql = ["pymysql"]
 odbc = ["pyodbc"]
@@ -76,9 +76,20 @@ setuptools.setup(
     license='MIT',
     python_requires=">=3.6",
     install_requires=[
-        'alembic<1.7', 'argparse', 'jsonpath-ng~=1.5', 'openpyxl==2.5.12',
-        'python-dateutil', 'requests', 'ndg-httpsclient', 'simplejson', 'six',
-        'sqlalchemy', 'pytz', 'sqlalchemy-migrate', 'backoff', 'csv342'
+        'alembic',
+        'argparse',
+        'backoff',
+        'csv342',
+        'jsonpath-ng~=1.5',
+        'ndg-httpsclient',
+        'openpyxl==2.5.12',
+        'python-dateutil',
+        'pytz',
+        'requests',
+        'simplejson',
+        'six',
+        'sqlalchemy',
+        'sqlalchemy-migrate'
     ],
     extras_require={
         'test': test_deps,


### PR DESCRIPTION
This change allows us to support the current stable version of Alembic, by fixing an import error.

I have checked all other Alembic imports, and they all check out OK. Local testing succeeded.
