### PR TITLE
Drop csv342

### DIFF
--- a/commcare_export/writers.py
+++ b/commcare_export/writers.py
@@ -1,3 +1,4 @@
+import csv
 import datetime
 import io
 import logging
@@ -6,7 +7,6 @@ from itertools import zip_longest
 
 import sqlalchemy
 
-import csv342 as csv
 from alembic.migration import MigrationContext
 from alembic.operations import Operations
 from commcare_export.data_types import UnknownDataType, get_sqlalchemy_type
@@ -88,17 +88,11 @@ class CsvTableWriter(TableWriter):
         if self.archive is None:
             raise Exception('Attempt to write to a closed CsvWriter')
 
-        def _encode_row(row):
-            return [
-                val.encode('utf-8') if isinstance(val, bytes) else val
-                for val in row
-            ]
-
         tempfile = io.StringIO()
         writer = csv.writer(tempfile, dialect=csv.excel)
-        writer.writerow(_encode_row(table.headings))
+        writer.writerow(table.headings)
         for row in table.rows:
-            writer.writerow(_encode_row(row))
+            writer.writerow(row)
 
         # TODO: make this a polite zip and put everything in a subfolder with the same basename
         # as the zipfile

--- a/setup.py
+++ b/setup.py
@@ -79,7 +79,6 @@ setuptools.setup(
         'alembic',
         'argparse',
         'backoff',
-        'csv342',
         'jsonpath-ng~=1.5',
         'ndg-httpsclient',
         'openpyxl==2.5.12',

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,3 +1,4 @@
+import csv
 import os
 import re
 import unittest
@@ -9,7 +10,6 @@ from unittest import mock
 import sqlalchemy
 from tests.utils import SqlWriterWithTearDown
 
-import csv342 as csv
 import pytest
 from commcare_export.checkpoint import (
     Checkpoint,

--- a/tests/test_writers.py
+++ b/tests/test_writers.py
@@ -1,3 +1,4 @@
+import csv
 import datetime
 import io
 import tempfile
@@ -6,7 +7,6 @@ import zipfile
 import openpyxl
 import sqlalchemy
 
-import csv342 as csv
 import pytest
 from commcare_export.specs import TableSpec
 from commcare_export.writers import (


### PR DESCRIPTION
csv342 backports Python 3's csv library to Python 2. We don't need it any more.

CSV export tested locally.
