### PR TITLE
Move types from docstrings into type hints

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,12 +28,15 @@ install:
  - pip install pymysql psycopg2 pyodbc
  - pip install coverage coveralls
  - sudo ACCEPT_EULA=Y apt-get install msodbcsql17
+ - pip install mypy
 before_script:
  - mysql -u root -e "GRANT ALL PRIVILEGES ON *.* TO 'travis'@'%';";
  - docker ps -a
  - odbcinst -q -d
  - .travis/wait.sh
-script: coverage run setup.py test
+script:
+ - coverage run setup.py test
+ - mypy --install-types --non-interactive @mypy_typed_modules.txt
 after_success:
  - coveralls
 services:

--- a/commcare_export/env.py
+++ b/commcare_export/env.py
@@ -2,6 +2,7 @@ import hashlib
 import json
 import operator
 import uuid
+from typing import Any, Dict, Union, overload
 
 import pytz
 
@@ -42,20 +43,16 @@ class Env(object):
     #
     # Interface
     #
-    def bind(self, name, value):
+    def bind(self, name: str, value: Any) -> 'Env':
         """
-        (key, ??) -> Env 
-
         Returns a new environment that is equivalent to the current
         except the provided key is bound to the value passed in. If the
         environment does not support such a binding, raises  CannotBind
         """
         raise NotImplementedError()
 
-    def lookup(self, key):
+    def lookup(self, key: str) -> Any:
         """
-        key -> ??
-
         Note that the return value may be ``None`` which may mean the
         value was unbound or may mean it was found and was None. This
         may need revisiting. This may also raise NotFound if it is the
@@ -63,10 +60,8 @@ class Env(object):
         """
         raise NotImplementedError()
 
-    def replace(self, data):
+    def replace(self, data: dict) -> 'Env':
         """
-        data -> Env
-
         Completely replace the environment with new data (somewhat like
         "this"-based Map functions a la jQuery). Could be the same as
         creating a new empty env and binding "@" in JsonPath.
@@ -212,8 +207,10 @@ class JsonPathEnv(Env):
             JSONPATH_CACHE[jsonpath_string] = parse_jsonpath(jsonpath_string)
         return JSONPATH_CACHE[jsonpath_string]
 
-    def lookup(self, name):
-        "str|JsonPath -> ??"
+    def lookup(
+        self,
+        name: Union[str, jsonpath.JSONPath]
+    ) -> RepeatableIterator:
         if isinstance(name, str):
             jsonpath_expr = self.parse(name)
         elif isinstance(name, jsonpath.JSONPath):
@@ -238,9 +235,15 @@ class JsonPathEnv(Env):
 
         return RepeatableIterator(iterator)
 
-    def bind(self, *args):
-        "(str, ??) -> Env | ({str: ??}) -> Env"
+    @overload
+    def bind(self, key: str, value: Any, *args) -> Env:
+        ...
 
+    @overload
+    def bind(self, bindings: Dict[str, Any], *args) -> Env:
+        ...
+
+    def bind(self, *args):
         new_bindings = dict(self.__bindings)
         if isinstance(args[0], dict):
             new_bindings.update(args[0])

--- a/commcare_export/env.py
+++ b/commcare_export/env.py
@@ -60,7 +60,7 @@ class Env(object):
         """
         raise NotImplementedError()
 
-    def replace(self, data: dict) -> 'Env':
+    def replace(self, data: Dict[str, Any]) -> 'Env':
         """
         Completely replace the environment with new data (somewhat like
         "this"-based Map functions a la jQuery). Could be the same as
@@ -412,9 +412,9 @@ def format_uuid(val):
 
 
 def join(*args):
-    args = [unwrap_val(arg) for arg in args]
+    args_ = [unwrap_val(arg) for arg in args]
     try:
-        return args[0].join(args[1:])
+        return args_[0].join(args_[1:])
     except TypeError:
         return '""'
 
@@ -463,8 +463,8 @@ def _doc_url(url_path):
 
 
 def template(format_template, *args):
-    args = [unwrap_val(arg) for arg in args]
-    return format_template.format(*args)
+    args_ = [unwrap_val(arg) for arg in args]
+    return format_template.format(*args_)
 
 
 def _or(*args):

--- a/commcare_export/minilinq.py
+++ b/commcare_export/minilinq.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Any
+from typing import Any, Dict
 from typing import List as ListType
 from typing import Optional
 
@@ -25,7 +25,7 @@ class MiniLinq(object):
 
     #### Factory methods ####
 
-    _node_classes = {}
+    _node_classes: Dict[str, 'MiniLinq'] = {}
 
     @classmethod
     def register(cls, clazz, slug=None):
@@ -71,6 +71,9 @@ class MiniLinq(object):
                 )
 
             return cls._node_classes[slug].from_jvalue(jvalue)
+
+    def to_jvalue(self):
+        raise NotImplementedError()
 
 
 class Reference(MiniLinq):
@@ -175,11 +178,6 @@ class Bind(MiniLinq):
                 'body': self.body.to_jvalue()
             }
         }
-
-    def __repr__(self):
-        return '%s(name=%r, value=%r, body=%r)' % (
-            self.__class__.__name__, self.name, self.value, self.body
-        )
 
 
 class Filter(MiniLinq):
@@ -476,8 +474,8 @@ class Emit(MiniLinq):
     def __init__(
         self,
         table: str,
-        headings: ListType[str],
-        source: ListType[MiniLinq],
+        headings: ListType[MiniLinq],
+        source: MiniLinq,
         missing_value=None,
         data_types=None,
     ):

--- a/commcare_export/minilinq.py
+++ b/commcare_export/minilinq.py
@@ -1,6 +1,9 @@
 import logging
+from typing import Any
 from typing import List as ListType
+from typing import Optional
 
+from commcare_export.env import Env
 from commcare_export.misc import unwrap, unwrap_val
 from commcare_export.repeatable_iterator import RepeatableIterator
 from commcare_export.specs import TableSpec
@@ -17,8 +20,7 @@ class MiniLinq(object):
     def __init__(self, *args, **kwargs):
         raise NotImplementedError()
 
-    def eval(self, env):
-        "( env: object(bindings: {str: ??}, writer: Writer) )-> ??"
+    def eval(self, env: Env) -> Any:
         raise NotImplementedError()
 
     #### Factory methods ####
@@ -138,8 +140,7 @@ class Bind(MiniLinq):
     too large to store, so it'll be re-run on each access.
     """
 
-    def __init__(self, name, value, body):
-        "(str, MiniLinq, MiniLinq) -> MiniLinq"
+    def __init__(self, name: str, value: MiniLinq, body: MiniLinq) -> None:
         self.name = name
         self.value = value
         self.body = body
@@ -186,8 +187,12 @@ class Filter(MiniLinq):
     Just what it sounds like
     """
 
-    def __init__(self, source, predicate, name=None):
-        "(MiniLinq, MiniLinq, var?) -> MiniLinq"
+    def __init__(
+        self,
+        source: MiniLinq,
+        predicate: MiniLinq,
+        name: Optional[str] = None
+    ) -> None:
         self.source = source
         self.name = name
         self.predicate = predicate
@@ -277,8 +282,12 @@ class Map(MiniLinq):
     enabling references to the rest of the env.
     """
 
-    def __init__(self, source, body, name=None):
-        "(MiniLinq, MiniLinq, var?) -> MiniLinq"
+    def __init__(
+        self,
+        source: MiniLinq,
+        body: MiniLinq,
+        name: Optional[str] = None
+    ) -> None:
         self.source = source
         self.name = name
         self.body = body
@@ -336,8 +345,12 @@ class FlatMap(MiniLinq):
     enabling references to the rest of the env.
     """
 
-    def __init__(self, source, body, name=None):
-        "(MiniLinq, MiniLinq, var?) -> MiniLinq"
+    def __init__(
+        self,
+        source: MiniLinq,
+        body: MiniLinq,
+        name: Optional[str] = None
+    ) -> None:
         self.source = source
         self.name = name
         self.body = body

--- a/commcare_export/utils.py
+++ b/commcare_export/utils.py
@@ -2,6 +2,7 @@ import sys
 
 from commcare_export import misc
 from commcare_export.checkpoint import CheckpointManager
+from commcare_export.specs import TableSpec
 from commcare_export.writers import StreamingMarkdownTableWriter
 
 
@@ -50,8 +51,9 @@ def print_runs(runs):
 
     StreamingMarkdownTableWriter(
         sys.stdout, compute_widths=True
-    ).write_table({
-        'headings': [
+    ).write_table(TableSpec(
+        name='',
+        headings=[
             "Checkpoint Time",
             "Batch end date",
             "Export Complete",
@@ -62,5 +64,5 @@ def print_runs(runs):
             "Table",
             "CommCare HQ"
         ],
-        'rows': rows
-    })
+        rows=rows,
+    ))

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,5 +1,3 @@
-# Global options:
-
 [mypy]
 python_version = 3.9
 follow_imports = silent
@@ -27,9 +25,3 @@ warn_unreachable = True
 
 # Reporting
 show_error_codes = True
-
-
-# Per-module options:
-
-# [mypy-commcare_export.minilinq]
-# disallow_untyped_defs = True

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,35 @@
+# Global options:
+
+[mypy]
+python_version = 3.9
+follow_imports = silent
+
+# TODO: Get or create stubs for libraries. Until then:
+ignore_missing_imports = True
+
+# Typing strictness
+check_untyped_defs = True
+disallow_subclassing_any = True
+disallow_any_generics = True
+warn_return_any = True
+strict_equality = True
+# Set "disallow_untyped_defs = True" for completely typed modules in
+# per-module options below
+
+# Check for drift
+warn_redundant_casts = True
+warn_unused_ignores = True
+warn_unused_configs = True
+
+# Non-typing checks
+implicit_reexport = False
+warn_unreachable = True
+
+# Reporting
+show_error_codes = True
+
+
+# Per-module options:
+
+# [mypy-commcare_export.minilinq]
+# disallow_untyped_defs = True

--- a/mypy_typed_modules.txt
+++ b/mypy_typed_modules.txt
@@ -1,0 +1,2 @@
+commcare_export/env.py
+commcare_export/minilinq.py


### PR DESCRIPTION
Controversial, I know. But `env.py` and `minilinq.py` have had type hints since 2013. They were just in docstrings. This change converts what was written in the docstrings to actual type hints, and adds automated checking with Travis.