### PR TITLE
We don't need to reflect all the tables

### DIFF
--- a/commcare_export/writers.py
+++ b/commcare_export/writers.py
@@ -510,10 +510,7 @@ class SqlTableWriter(SqlMixin, TableWriter):
             self._create_table(table_name, row_dict, data_type_dict)
             return
 
-        def get_current_table_columns():
-            return {c.name: c for c in self.table(table_name).columns}
-
-        columns = get_current_table_columns()
+        columns = {c.name: c for c in self.table(table_name).columns}
 
         for column, val in row_dict.items():
             if val is None:
@@ -528,7 +525,6 @@ class SqlTableWriter(SqlMixin, TableWriter):
                     table_name, sqlalchemy.Column(column, ty, nullable=True)
                 )
                 self.metadata.clear()
-                columns = get_current_table_columns()
             elif not columns[column].primary_key:
                 current_ty = columns[column].type
                 new_type = None
@@ -552,7 +548,6 @@ class SqlTableWriter(SqlMixin, TableWriter):
                     )
                     op.alter_column(table_name, column, type_=new_type)
                     self.metadata.clear()
-                    columns = get_current_table_columns()
 
     def _create_table(self, table_name, row_dict, data_type_dict):
         ctx = MigrationContext.configure(self.connection)

--- a/commcare_export/writers.py
+++ b/commcare_export/writers.py
@@ -501,16 +501,15 @@ class SqlTableWriter(SqlMixin, TableWriter):
         return sqlalchemy.UnicodeText(collation=self.collation)
 
     def make_table_compatible(self, table_name, row_dict, data_type_dict):
-        ctx = MigrationContext.configure(self.connection)
-        op = Operations(ctx)
-
         try:
-            self.table(table_name)
+            table = self.table(table_name)
         except NoSuchTableError:
             self._create_table(table_name, row_dict, data_type_dict)
             return
 
-        columns = {c.name: c for c in self.table(table_name).columns}
+        ctx = MigrationContext.configure(self.connection)
+        op = Operations(ctx)
+        columns = {c.name: c for c in table.columns}
 
         for column, val in row_dict.items():
             if val is None:

--- a/commcare_export/writers.py
+++ b/commcare_export/writers.py
@@ -593,12 +593,12 @@ class SqlTableWriter(SqlMixin, TableWriter):
                       .values(**row_dict))
             self.connection.execute(update)
 
-    def write_table(self, table: TableSpec) -> None:
-        table_name = table.name
-        headings = table.headings
-        data_type_dict = dict(zip_longest(headings, table.data_types))
+    def write_table(self, table_spec: TableSpec) -> None:
+        table_name = table_spec.name
+        headings = table_spec.headings
+        data_type_dict = dict(zip_longest(headings, table_spec.data_types))
         # Rather inefficient for now...
-        for row in table.rows:
+        for row in table_spec.rows:
             row_dict = dict(zip(headings, row))
             self.make_table_compatible(table_name, row_dict, data_type_dict)
             self.upsert(self.table(table_name), row_dict)

--- a/commcare_export/writers.py
+++ b/commcare_export/writers.py
@@ -517,6 +517,7 @@ class SqlTableWriter(SqlMixin, TableWriter):
                     sqlalchemy.Column(column, val_type, nullable=True)
                 )
                 self.metadata.clear()
+                table = self.get_table(table.name)
             elif not columns[column].primary_key:
                 col_type = columns[column].type
                 new_col_type = None
@@ -536,6 +537,8 @@ class SqlTableWriter(SqlMixin, TableWriter):
                     )
                     op.alter_column(table.name, column, type_=new_col_type)
                     self.metadata.clear()
+                    table = self.get_table(table.name)
+        return table
 
     def create_table(self, table_name, row_dict, data_type_dict):
         ctx = MigrationContext.configure(self.connection)
@@ -607,7 +610,7 @@ class SqlTableWriter(SqlMixin, TableWriter):
             # Checks the data type for every cell in every row. Maybe we
             # can use a future version of the data dictionary to avoid
             # this?
-            self.make_table_compatible(table, row_dict, data_type_dict)
+            table = self.make_table_compatible(table, row_dict, data_type_dict)
             self.upsert(table, row_dict)
 
     def _get_columns_for_data(self, row_dict, data_type_dict):

--- a/tests/test_checkpointmanager.py
+++ b/tests/test_checkpointmanager.py
@@ -48,7 +48,8 @@ class TestCheckpointManager(object):
     def test_create_checkpoint_table(self, manager, revision='head'):
         manager.create_checkpoint_table(revision)
         with manager:
-            assert 'commcare_export_runs' in manager.metadata.tables
+            table = manager.get_table('commcare_export_runs')
+            assert table is not None
 
     def test_checkpoint_table_exists(self, manager):
         # Test that the migrations don't fail for tables that existed before

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -723,9 +723,12 @@ class TestCLIWithDataTypes(object):
         )
 
         metadata = sqlalchemy.schema.MetaData(bind=writer.engine)
-        metadata.reflect()
-
-        cols = metadata.tables['forms'].c
+        table = sqlalchemy.Table(
+            'forms',
+            metadata,
+            autoload_with=writer.engine,
+        )
+        cols = table.c
         assert sorted([c.name for c in cols]) == sorted([
             u'id', u'a_bool', u'an_int', u'a_date', u'a_datetime', u'a_text'
         ])

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -7,10 +7,10 @@ class SqlWriterWithTearDown(SqlTableWriter):
         super().__init__(*args, **kwargs)
         self.tables = set()
 
-    def write_table(self, table):
-        super().write_table(table)
-        if table.rows:
-            self.tables.add(table.name)
+    def write_table(self, table_spec):
+        super().write_table(table_spec)
+        if table_spec.rows:
+            self.tables.add(table_spec.name)
 
     def tear_down(self):
         for table in self.tables:


### PR DESCRIPTION
Context: [SC-2022](https://dimagi-dev.atlassian.net/browse/SC-2022)

This change improves performance by avoiding [reflecting all the tables](https://docs.sqlalchemy.org/en/14/core/reflection.html#reflecting-all-tables-at-once) in a database.

This change has been tested with:
- [x] Adding a table with `--strict-types`
- [x] Adding a table without `--strict-types`
- [x] Adding columns to an existing table with `--strict-types`
- [x] Adding columns to an existing table without `--strict-types`

Easier to :blowfish: review :tropical_fish: by :fish: commit.
