### PR TITLE
Preserve values of duplicate filter names

### DIFF
--- a/commcare_export/excel_query.py
+++ b/commcare_export/excel_query.py
@@ -122,7 +122,12 @@ def compile_filters(worksheet, mappings=None):
             for cell in get_column_by_name(worksheet, 'filter value') or []
         ]
     )
-    return zip(filter_names, filter_values)
+    # Preserve values of duplicate filter names. Results in an OR filter.
+    # e.g. {'type': ['person'], 'owner_id': ['abc123', 'def456']}
+    filters = defaultdict(list)
+    for k, v in zip(filter_names, filter_values):
+        filters[k].append(v)
+    return filters
 
 
 def extended_to_len(desired_len, some_list, value=None):
@@ -350,7 +355,7 @@ def compile_source(worksheet, value_or_root=False):
             # conditional
             api_query_args.append(Literal(None))
     else:
-        api_query_args.append(Literal(dict(filters)))
+        api_query_args.append(Literal(filters))
 
     if include_referenced_items:
         api_query_args.append(Literal(include_referenced_items))

--- a/commcare_export/excel_query.py
+++ b/commcare_export/excel_query.py
@@ -504,12 +504,10 @@ def parse_sheet(
     )
 
 
-class SheetParts(
-    namedtuple(
-        'SheetParts',
-        'name headings source body root_expr data_types data_source'
-    )
-):
+class SheetParts(namedtuple(
+    'SheetParts',
+    'name headings source body root_expr data_types data_source'
+)):
 
     def __new__(
         cls,
@@ -521,15 +519,14 @@ class SheetParts(
         data_types=None,
         data_source=None
     ):
-        data_types = data_types or []
-        return super(SheetParts, cls).__new__(
+        return super().__new__(
             cls,
             name,
             headings,
             source,
             body,
             root_expr,
-            data_types,
+            data_types or [],
             data_source
         )
 

--- a/tests/test_excel_query.py
+++ b/tests/test_excel_query.py
@@ -132,8 +132,8 @@ class TestExcelQuery(unittest.TestCase):
                         Reference("api_data"), Literal("form"),
                         Reference("checkpoint_manager"),
                         Literal({
-                            'app_id': 'foobizzle',
-                            'type': 'intake',
+                            'app_id': ['foobizzle'],
+                            'type': ['intake'],
                         })
                     ),
                     body=None,


### PR DESCRIPTION
Context: [SC-2201](https://dimagi-dev.atlassian.net/browse/SC-2201)
PR for Case List API support: https://github.com/dimagi/commcare-hq/pull/32566

If a filter name is repeated with multiple filter values, commcare-export will pass both values to the API, not just the last one.

Once the PR linked above is merged, the Case List API will return cases that match any of the values. (In other words, an "OR" filter will be applied to multiple values of the same filter name.)

Tested locally.

fyi @joxl / SAAS
