### PR TITLE
Add UCR support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,6 +48,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - run: sudo apt-get install pandoc
       - run: python setup.py sdist
+      - run: pip install --upgrade pip
       - run: pip install dist/*
       - run: pip install pymysql psycopg2 pyodbc
       - run: pip install coverage coveralls

--- a/commcare_export/commcare_minilinq.py
+++ b/commcare_export/commcare_minilinq.py
@@ -20,7 +20,8 @@ SUPPORTED_RESOURCES = {
     'location',
     'application',
     'web-user',
-    'messaging-event'
+    'messaging-event',
+    'ucr',
 }
 
 
@@ -109,6 +110,7 @@ def get_paginator(
             'form': DatePaginator('indexed_on', page_size),
             'case': DatePaginator('indexed_on', page_size),
             'messaging-event': DatePaginator('date_last_activity', page_size),
+            'ucr': UCRPaginator(page_size),
         },
         PaginationMode.date_modified: {
             'form':
@@ -121,6 +123,7 @@ def get_paginator(
                 DatePaginator('server_date_modified', page_size),
             'messaging-event':
                 DatePaginator('date_last_activity', page_size),
+            'ucr': UCRPaginator(page_size),
         }
     }[pagination_mode].get(resource, SimplePaginator(page_size))
 
@@ -262,3 +265,11 @@ class DatePaginator(SimplePaginator):
                     )
                 except ParserError:
                     return None
+
+
+class UCRPaginator(SimplePaginator):
+
+    def next_page_params_from_batch(self, batch):
+        params = super(UCRPaginator, self).next_page_params_from_batch(batch)
+        if params:
+            return params | self.payload


### PR DESCRIPTION
[Ticket](https://dimagi-dev.atlassian.net/browse/SC-2911)

Background:
This work adds support to the DET for exporting data sources from CommCareHQ using the `api_get_ucr_data` API endpoint.

Due to the generic nature of the DET, not much work was needed to make the UCR exports compatible. 

One thing to note:
The datasources on HQ is stored in a custom table. This table does not have an `id` column and uses the `doc_id` column as the primary key. When HQ gives the datasource data it adds an `id` column (in addition to the `doc_id` column) which contains the same value as the `doc_id` column, but this new `id` column is the primary key in the DET database. If this is a problem I can change that, but that will require some additional changes to the DET.