### PR TITLE
Fix for datasource's paginator page_size

### DIFF
--- a/commcare_export/commcare_minilinq.py
+++ b/commcare_export/commcare_minilinq.py
@@ -305,8 +305,8 @@ class DatePaginator(SimplePaginator):
 
 class UCRPaginator(SimplePaginator):
     def __init__(self, page_size=None, *args, **kwargs):
-        page_size = page_size if page_size else DEFAULT_UCR_PAGE_SIZE
         super().__init__(page_size, *args, **kwargs)
+        self.page_size = page_size if page_size else DEFAULT_UCR_PAGE_SIZE
 
     def next_page_params_from_batch(self, batch):
         params = super(UCRPaginator, self).next_page_params_from_batch(batch)
@@ -315,6 +315,7 @@ class UCRPaginator(SimplePaginator):
 
     def next_page_params_since(self, since=None):
         params = self.payload | {'cursor': since}
+        params["limit"] = self.page_size
         return params
 
     def set_checkpoint(self, checkpoint_manager, batch, is_final):

--- a/commcare_export/commcare_minilinq.py
+++ b/commcare_export/commcare_minilinq.py
@@ -314,7 +314,8 @@ class UCRPaginator(SimplePaginator):
             return params | self.payload
 
     def next_page_params_since(self, since=None):
-        params = self.payload | {'cursor': since}
+        params = self.payload
+        params['cursor'] = since
         params["limit"] = self.page_size
         return params
 

--- a/tests/test_paginator.py
+++ b/tests/test_paginator.py
@@ -1,0 +1,33 @@
+import unittest
+
+from commcare_export.checkpoint import CheckpointManagerWithDetails
+from commcare_export.commcare_minilinq import (
+    DEFAULT_UCR_PAGE_SIZE,
+    PaginationMode,
+    get_paginator,
+)
+
+
+class PaginatorTest(unittest.TestCase):
+    def test_ucr_paginator_page_size(self):
+        checkpoint_manager = CheckpointManagerWithDetails(
+            None, None, PaginationMode.cursor
+        )
+        paginator = get_paginator(
+            resource="ucr",
+            pagination_mode=checkpoint_manager.pagination_mode)
+        paginator.init()
+        initial_params = paginator.next_page_params_since(
+            checkpoint_manager.since_param
+        )
+        self.assertEqual(initial_params["limit"], DEFAULT_UCR_PAGE_SIZE)
+
+        paginator = get_paginator(
+            resource="ucr",
+            page_size=1,
+            pagination_mode=checkpoint_manager.pagination_mode)
+        paginator.init()
+        initial_params = paginator.next_page_params_since(
+            checkpoint_manager.since_param
+        )
+        self.assertEqual(initial_params["limit"], 1)


### PR DESCRIPTION
This PR fixes two issues:
1. the default page size was set to 1k which is the non-datesource default. This is now set to the DEFAULT_UCR_PAGE_SIZE, which is 10k.
2. the page_size (or batch-size) wasn't being passed as a query parameter