### PR TITLE
Show detailed exception only when needed

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -64,4 +64,8 @@ jobs:
           HQ_API_KEY: ${{ secrets.HQ_API_KEY }}
       - run: mypy --install-types --non-interactive @mypy_typed_modules.txt
       - run: coverage lcov -o coverage/lcov.info
-      - uses: coverallsapp/github-action@v1
+      - name: Coveralls
+        uses: coverallsapp/github-action@v2
+        with:
+          github-token:
+            ${{ secrets.GITHUB_TOKEN }}

--- a/commcare_export/commcare_hq_client.py
+++ b/commcare_export/commcare_hq_client.py
@@ -9,6 +9,7 @@ from __future__ import (
 
 import copy
 import logging
+import sys
 import time
 from collections import OrderedDict
 from math import ceil
@@ -151,7 +152,15 @@ class CommCareHqClient(object):
                 resource_url, params=params, auth=self.__auth, timeout=60
             )
             if self._should_raise_for_status(response):
-                response.raise_for_status()
+                try:
+                    response.raise_for_status()
+                except Exception as e:
+                    # for non-verbose output, skip the stacktrace
+                    if not logger.isEnabledFor(logging.DEBUG):
+                        logger.error(str(e))
+                        sys.exit()
+                    raise e
+
             return response
 
         response = _get(resource, params)

--- a/commcare_export/commcare_hq_client.py
+++ b/commcare_export/commcare_hq_client.py
@@ -159,7 +159,7 @@ class CommCareHqClient(object):
                     if not logger.isEnabledFor(logging.DEBUG):
                         if isinstance(e, requests.exceptions.HTTPError) and response.status_code == 401:
                             logger.error(
-                                f"#{e}. Please ensure that your CommCare HQ credentials are correct and auth-mode"
+                                f"#{e}. Please ensure that your CommCare HQ credentials are correct and auth-mode "
                                 f"is passed as 'apikey' if using API Key to authenticate. Also, verify that your "
                                 f"account has the necessary permissions to access the DET tool."
                             )

--- a/commcare_export/commcare_hq_client.py
+++ b/commcare_export/commcare_hq_client.py
@@ -127,7 +127,7 @@ class CommCareHqClient(object):
         the amount of seconds specified in the Retry-After header from the response, after which it will raise
         an exception to trigger the retry action.
 
-        Currently a bit of a vulnerable stub that works for this
+        Currently, a bit of a vulnerable stub that works for this
         particular use case in the hands of a trusted user; would likely
         want this to work like (or via) slumber.
         """

--- a/commcare_export/commcare_hq_client.py
+++ b/commcare_export/commcare_hq_client.py
@@ -162,7 +162,7 @@ class CommCareHqClient(object):
                             logger.error(
                                 f"#{e}. Please ensure that your CommCare HQ credentials are correct and auth-mode "
                                 f"is passed as 'apikey' if using API Key to authenticate. Also, verify that your "
-                                f"account has the necessary permissions to access the DET tool."
+                                f"account has the necessary permissions to use commcare-export."
                             )
                         else:
                             logger.error(str(e))

--- a/commcare_export/commcare_hq_client.py
+++ b/commcare_export/commcare_hq_client.py
@@ -160,7 +160,7 @@ class CommCareHqClient(object):
                         if isinstance(e, requests.exceptions.HTTPError) and response.status_code == 401:
                             logger.error(
                                 f"#{e}. Please ensure that your CommCare HQ credentials are correct & valid for "
-                                f"the auth-mode passed. Also, Verify that your account has the necessary "
+                                f"the auth-mode passed. Also, verify that your account has the necessary "
                                 f"permissions to access the DET tool."
                             )
                         else:

--- a/commcare_export/commcare_hq_client.py
+++ b/commcare_export/commcare_hq_client.py
@@ -83,7 +83,6 @@ class CommCareHqClient(object):
         password,
         auth_mode=AUTH_MODE_PASSWORD,
         version=LATEST_KNOWN_VERSION,
-        checkpoint_manager=None
     ):
         self.version = version
         self.url = url
@@ -91,7 +90,8 @@ class CommCareHqClient(object):
         self.__auth = self._get_auth(username, password, auth_mode)
         self.__session = None
 
-    def _get_auth(self, username, password, mode):
+    @staticmethod
+    def _get_auth(username, password, mode):
         if mode == AUTH_MODE_PASSWORD:
             return HTTPDigestAuth(username, password)
         elif mode == AUTH_MODE_APIKEY:
@@ -117,7 +117,8 @@ class CommCareHqClient(object):
     def api_url(self):
         return '%s/a/%s/api/v%s' % (self.url, self.project, self.version)
 
-    def _should_raise_for_status(self, response):
+    @staticmethod
+    def _should_raise_for_status(response):
         return "Retry-After" not in response.headers
 
     def get(self, resource, params=None):

--- a/commcare_export/commcare_hq_client.py
+++ b/commcare_export/commcare_hq_client.py
@@ -10,7 +10,6 @@ from __future__ import (
 import copy
 import logging
 import sys
-import time
 from collections import OrderedDict
 from math import ceil
 from urllib.parse import urlencode
@@ -21,7 +20,6 @@ from requests.auth import AuthBase, HTTPDigestAuth
 
 import commcare_export
 from commcare_export.repeatable_iterator import RepeatableIterator
-from datetime import datetime
 
 AUTH_MODE_PASSWORD = 'password'
 AUTH_MODE_APIKEY = 'apikey'
@@ -31,9 +29,11 @@ logger = logging.getLogger(__name__)
 LATEST_KNOWN_VERSION = '0.5'
 RESOURCE_REPEAT_LIMIT = 10
 
+
 def on_wait(details):
     time_to_wait = details["wait"]
     logger.warning(f"Rate limit reached. Waiting for {time_to_wait} seconds.")
+
 
 def on_backoff(details):
     _log_backoff(details, 'Waiting for retry.')

--- a/commcare_export/commcare_hq_client.py
+++ b/commcare_export/commcare_hq_client.py
@@ -159,9 +159,9 @@ class CommCareHqClient(object):
                     if not logger.isEnabledFor(logging.DEBUG):
                         if isinstance(e, requests.exceptions.HTTPError) and response.status_code == 401:
                             logger.error(
-                                f"#{e}. Please ensure that your CommCare HQ credentials are correct & valid for "
-                                f"the auth-mode passed. Also, verify that your account has the necessary "
-                                f"permissions to access the DET tool."
+                                f"#{e}. Please ensure that your CommCare HQ credentials are correct and auth-mode"
+                                f"is passed as 'apikey' if using API Key to authenticate. Also, verify that your "
+                                f"account has the necessary permissions to access the DET tool."
                             )
                         else:
                             logger.error(str(e))

--- a/commcare_export/commcare_hq_client.py
+++ b/commcare_export/commcare_hq_client.py
@@ -185,13 +185,13 @@ class CommCareHqClient(object):
         Assumes the endpoint is a list endpoint, and iterates over it
         making a lot of assumptions that it is like a tastypie endpoint.
         """
-        UNKNOWN_COUNT = 'unknown'
+        unknown_count = 'unknown'
         params = dict(params or {})
 
         def iterate_resource(resource=resource, params=params):
             more_to_fetch = True
             last_batch_ids = set()
-            total_count = UNKNOWN_COUNT
+            total_count = unknown_count
             fetched = 0
             repeat_counter = 0
             last_params = None
@@ -210,11 +210,11 @@ class CommCareHqClient(object):
                 batch = self.get(resource, params)
                 last_params = copy.copy(params)
                 batch_meta = batch['meta']
-                if total_count == UNKNOWN_COUNT or fetched >= total_count:
+                if total_count == unknown_count or fetched >= total_count:
                     if batch_meta.get('total_count'):
                         total_count = int(batch_meta['total_count'])
                     else:
-                        total_count = UNKNOWN_COUNT
+                        total_count = unknown_count
                     fetched = 0
 
                 batch_objects = batch['objects']
@@ -242,7 +242,7 @@ class CommCareHqClient(object):
                         # Handle the case where API is 'non-counting'
                         # and repeats the last batch
                         repeated_last_page_of_non_counting_resource = (
-                            not got_new_data and total_count == UNKNOWN_COUNT
+                            not got_new_data and total_count == unknown_count
                             and (limit and len(batch_objects) < limit)
                         )
                         more_to_fetch = not repeated_last_page_of_non_counting_resource

--- a/commcare_export/commcare_hq_client.py
+++ b/commcare_export/commcare_hq_client.py
@@ -157,7 +157,14 @@ class CommCareHqClient(object):
                 except Exception as e:
                     # for non-verbose output, skip the stacktrace
                     if not logger.isEnabledFor(logging.DEBUG):
-                        logger.error(str(e))
+                        if isinstance(e, requests.exceptions.HTTPError) and response.status_code == 401:
+                            logger.error(
+                                f"#{e}. Please ensure that your CommCare HQ credentials are correct & valid for "
+                                f"the auth-mode passed. Also, Verify that your account has the necessary "
+                                f"permissions to access the DET tool."
+                            )
+                        else:
+                            logger.error(str(e))
                         sys.exit()
                     raise e
 

--- a/tests/test_commcare_hq_client.py
+++ b/tests/test_commcare_hq_client.py
@@ -330,7 +330,7 @@ class TestCommCareHqClient(unittest.TestCase):
             "#401 Client Error: None for url: None. "
             "Please ensure that your CommCare HQ credentials are correct and auth-mode is passed as 'apikey' "
             "if using API Key to authenticate. Also, verify that your account has the necessary permissions "
-            "to access the DET tool.")
+            "to use commcare-export.")
 
     @patch('commcare_export.commcare_hq_client.logger')
     @patch("commcare_export.commcare_hq_client.CommCareHqClient.session")


### PR DESCRIPTION
https://dimagi.atlassian.net/browse/SC-3354

`raise for status` raises an exception in case of authentication failures which leads to a full stacktrace shown.
Seems reasonable to limit showing the full stacktrace only for verbose mode.
