### PR TITLE
Generate DET executable files

### DIFF
--- a/.github/workflows/release_actions.yml
+++ b/.github/workflows/release_actions.yml
@@ -1,0 +1,33 @@
+name: commcare-export release actions
+on:
+  release:
+    types: [published]
+
+jobs:
+  generate_release_assets:
+    name: Generate release assets
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Pull docker images for pyinstaller/wine
+        run: |
+          docker pull cdrx/pyinstaller-linux
+          docker pull cdrx/pyinstaller-windows
+
+      - name: Generate linux binary
+        run: |
+          docker run -v "$(pwd):/src/" cdrx/pyinstaller-linux
+
+      - name: Generate windows exe
+        run: |
+          docker run -v "$(pwd):/src/" cdrx/pyinstaller-windows
+
+      - name: Upload release assets
+        uses: AButler/upload-release-assets@v3.0
+        with:
+          files: "./dist/linux/*;./dist/windows/*"
+          repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release_actions.yml
+++ b/.github/workflows/release_actions.yml
@@ -10,19 +10,17 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Pull docker images for pyinstaller/wine
         run: |
           docker pull cdrx/pyinstaller-linux
           docker pull cdrx/pyinstaller-windows
 
-      - name: Generate linux binary
+      - name: Compile linux binary
         run: |
           docker run -v "$(pwd):/src/" cdrx/pyinstaller-linux
 
-      - name: Generate windows exe
+      - name: Compile windows exe
         run: |
           docker run -v "$(pwd):/src/" cdrx/pyinstaller-windows
 

--- a/README.md
+++ b/README.md
@@ -546,6 +546,11 @@ https://pypi.python.org/pypi/commcare-export
 
 https://github.com/dimagi/commcare-export/releases
 
+Once the release is created, a GitHub workflow is kicked off that generates two release artifacts, 
+which constitute executable files of the DET compatible with the following operating systems, namely
+1. Linux
+2. Windows
+
 
 Testing and Test Databases
 --------------------------
@@ -656,3 +661,18 @@ export HQ_API_KEY=<apikey>
 
 For Travis builds these are included as encrypted vars in the travis
 config.
+
+
+Compiling executable files locally
+-----------------------------------
+The DET executable files are compiled using a tool called [pyinstaller](https://pyinstaller.org/en/stable/).
+Pyinstaller is very easy to use, but only works out-of-the-box for Linux as support for cross-compilation was
+dropped in earlier releases. Another tool, [wine](https://www.winehq.org/), can be used in conjuction with
+pyinstaller to compile the Windows exe files.
+
+Luckily in the world we live there's a repo out there called [docker-pyinstaller](https://github.com/cdrx/docker-pyinstaller)
+which takes you through very simple steps to pull and use docker images to generate both the Linux binary and 
+Windows .exe files, so we don't ever have to worry about installing any additional packages ourselves.
+
+Please note that the `commcare-export.spec` file used by the docker containers is already defined and sits at the top of this project.
+It shouldn't be necessary for you to change any parameters in the file.

--- a/commcare-export.spec
+++ b/commcare-export.spec
@@ -6,7 +6,9 @@ a = Analysis(
     pathex=[],
     binaries=[],
     datas=[('./commcare_export', '.')],
-    hiddenimports=[],
+    hiddenimports=[
+        'sqlalchemy.sql.default_comparator',
+    ],
     hookspath=[],
     runtime_hooks=[],
     excludes=[],

--- a/commcare-export.spec
+++ b/commcare-export.spec
@@ -1,0 +1,37 @@
+# -*- mode: python ; coding: utf-8 -*-
+
+
+a = Analysis(
+    ['commcare_export/cli.py'],
+    pathex=[],
+    binaries=[],
+    datas=[('./commcare_export', '.')],
+    hiddenimports=[],
+    hookspath=[],
+    hooksconfig={},
+    runtime_hooks=[],
+    excludes=[],
+    noarchive=False,
+)
+pyz = PYZ(a.pure)
+
+exe = EXE(
+    pyz,
+    a.scripts,
+    a.binaries,
+    a.datas,
+    [],
+    name='commcare-export',
+    debug=False,
+    bootloader_ignore_signals=False,
+    strip=False,
+    upx=True,
+    upx_exclude=[],
+    runtime_tmpdir=None,
+    console=True,
+    disable_windowed_traceback=False,
+    argv_emulation=False,
+    target_arch=None,
+    codesign_identity=None,
+    entitlements_file=None,
+)

--- a/commcare-export.spec
+++ b/commcare-export.spec
@@ -8,7 +8,6 @@ a = Analysis(
     datas=[('./commcare_export', '.')],
     hiddenimports=[],
     hookspath=[],
-    hooksconfig={},
     runtime_hooks=[],
     excludes=[],
     noarchive=False,

--- a/commcare_export/cli.py
+++ b/commcare_export/cli.py
@@ -197,14 +197,14 @@ def main(argv):
 
     if args.version:
         print('commcare-export version {}'.format(__version__))
-        exit(0)
+        sys.exit(0)
 
     if not args.project:
         print(
             'commcare-export: error: argument --project is required',
             file=sys.stderr
         )
-        exit(1)
+        sys.exit(1)
 
     if args.profile:
         # hotshot is gone in Python 3
@@ -214,7 +214,7 @@ def main(argv):
         profile.start()
 
     try:
-        exit(main_with_args(args))
+        sys.exit(main_with_args(args))
     finally:
         if args.profile:
             profile.close()

--- a/commcare_export/utils_cli.py
+++ b/commcare_export/utils_cli.py
@@ -151,7 +151,7 @@ def main(argv):
         format='%(asctime)s %(name)-12s %(levelname)-8s %(message)s'
     )
 
-    exit(main_with_args(args))
+    sys.exit(main_with_args(args))
 
 
 def main_with_args(args):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,19 @@
+# This file is only used by pyinstaller to create the executable DET instance
+alembic
+argparse
+chardet
+backoff>=2.0
+jsonpath-ng~=1.6.0
+ndg-httpsclient
+openpyxl==2.5.12
+python-dateutil
+pytz
+psycopg2-binary
+pymysql
+pyodbc
+requests
+simplejson
+sqlalchemy~=1.4
+sqlalchemy-migrate
+urllib3==1.26.7
+xlwt


### PR DESCRIPTION
[Ticket](https://dimagi.atlassian.net/browse/SC-3351)

This PR broadens the DET horizons by introducing functionality to generate/compile executable files of the DET, each compatible with a different operating system. The supported operating systems are
1. Linux
2. Windows

Note that these two executable files are compiled automatically on every release publish and will be added as assets to the release once the workflow completes. Any person can then simply download the file(s) from there and use it (through the CLI) like you would as if you installed commcare-export,
> commcare-export < options >

The big push for this was the fact that some folks using the DET is less technically-inclined and having to manage a python codebase and it's packages poses a barrier to usage. Now users can simply download and run the file without thinking about any installation steps.