### PR TITLE
Cs/sc 3373 det log file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,4 @@ nosetests.xml
 
 # Excel
 ~*.xlsx
+commcare_export.log

--- a/commcare_export/__init__.py
+++ b/commcare_export/__init__.py
@@ -1,1 +1,25 @@
+import sys
+import logging
 from .version import __version__
+
+logging.basicConfig(
+    filename="commcare_export.log",
+    format='%(asctime)s %(name)-12s %(levelname)-8s %(message)s',
+    filemode='w',
+)
+
+
+class Logger:
+    def __init__(self, logger, level):
+        self.logger = logger
+        self.level = level
+        self.linebuf = ''
+
+    def write(self, buf):
+        for line in buf.rstrip().splitlines():
+            self.logger.log(self.level, line.rstrip())
+
+
+logger = logging.getLogger()
+logger.setLevel(logging.DEBUG)
+sys.stderr = Logger(logging.getLogger(), logging.ERROR)

--- a/commcare_export/__init__.py
+++ b/commcare_export/__init__.py
@@ -1,5 +1,8 @@
 import logging
+import os
 from .version import __version__
+
+repo_root = os.path.abspath(os.path.join(__file__, os.pardir, os.pardir))
 
 
 class Logger:
@@ -13,9 +16,26 @@ class Logger:
             self.logger.log(self.level, line.rstrip())
 
 
+def logger_name_from_filepath(filepath):
+    relative_path = os.path.relpath(filepath, start=repo_root)
+    return (
+        relative_path.
+        replace('/', '.').
+        replace('.py', '')
+    )
+
+
 def get_error_logger():
     return Logger(logging.getLogger(), logging.ERROR)
 
 
-logger = logging.getLogger()
-logger.setLevel(logging.DEBUG)
+def get_logger(filepath=None):
+    if filepath:
+        logger = logging.getLogger(
+            logger_name_from_filepath(filepath)
+        )
+    else:
+        logger = logging.getLogger()
+
+    logger.setLevel(logging.DEBUG)
+    return logger

--- a/commcare_export/__init__.py
+++ b/commcare_export/__init__.py
@@ -13,5 +13,9 @@ class Logger:
             self.logger.log(self.level, line.rstrip())
 
 
+def get_error_logger():
+    return Logger(logging.getLogger(), logging.ERROR)
+
+
 logger = logging.getLogger()
 logger.setLevel(logging.DEBUG)

--- a/commcare_export/__init__.py
+++ b/commcare_export/__init__.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import re
 from .version import __version__
 
 repo_root = os.path.abspath(os.path.join(__file__, os.pardir, os.pardir))
@@ -18,11 +19,8 @@ class Logger:
 
 def logger_name_from_filepath(filepath):
     relative_path = os.path.relpath(filepath, start=repo_root)
-    return (
-        relative_path.
-        replace('/', '.').
-        strip('.py')
-    )
+    cleaned_path = relative_path.replace('/', '.')
+    return re.sub(r'\.py$', '', cleaned_path)
 
 
 def get_error_logger():

--- a/commcare_export/__init__.py
+++ b/commcare_export/__init__.py
@@ -1,12 +1,5 @@
-import sys
 import logging
 from .version import __version__
-
-logging.basicConfig(
-    filename="commcare_export.log",
-    format='%(asctime)s %(name)-12s %(levelname)-8s %(message)s',
-    filemode='w',
-)
 
 
 class Logger:
@@ -22,4 +15,3 @@ class Logger:
 
 logger = logging.getLogger()
 logger.setLevel(logging.DEBUG)
-sys.stderr = Logger(logging.getLogger(), logging.ERROR)

--- a/commcare_export/__init__.py
+++ b/commcare_export/__init__.py
@@ -21,7 +21,7 @@ def logger_name_from_filepath(filepath):
     return (
         relative_path.
         replace('/', '.').
-        replace('.py', '')
+        strip('.py')
     )
 
 

--- a/commcare_export/checkpoint.py
+++ b/commcare_export/checkpoint.py
@@ -1,5 +1,4 @@
 import datetime
-import logging
 import os
 import uuid
 from contextlib import contextmanager
@@ -13,8 +12,8 @@ from sqlalchemy.orm import sessionmaker
 from commcare_export.commcare_minilinq import PaginationMode
 from commcare_export.exceptions import DataExportException
 from commcare_export.writers import SqlMixin
+from commcare_export import logger
 
-logger = logging.getLogger(__name__)
 repo_root = os.path.abspath(os.path.join(__file__, os.pardir, os.pardir))
 
 Base = declarative_base()

--- a/commcare_export/checkpoint.py
+++ b/commcare_export/checkpoint.py
@@ -12,10 +12,9 @@ from sqlalchemy.orm import sessionmaker
 from commcare_export.commcare_minilinq import PaginationMode
 from commcare_export.exceptions import DataExportException
 from commcare_export.writers import SqlMixin
-from commcare_export import logger
+from commcare_export import get_logger, repo_root
 
-repo_root = os.path.abspath(os.path.join(__file__, os.pardir, os.pardir))
-
+logger = get_logger(__file__)
 Base = declarative_base()
 
 

--- a/commcare_export/cli.py
+++ b/commcare_export/cli.py
@@ -216,13 +216,17 @@ def main(argv):
         profile.start()
 
     try:
-        print("Running...")
+        print("Running export...")
         try:
-            exit(main_with_args(args))
+            exit_code = main_with_args(args)
+            if exit_code > 0:
+                print("Error occurred! See log file for error.")
+            exit(exit_code)
         except Exception:
             print("Error occurred! See log file for error.")
             raise
     finally:
+        print("Export finished!")
         if args.profile:
             profile.close()
             stats = hotshot.stats.load(args.profile)
@@ -415,9 +419,11 @@ def main_with_args(args):
         return EXIT_STATUS_ERROR
 
     if not args.username:
+        logger.warn("Username not provided")
         args.username = input('Please provide a username: ')
 
     if not args.password:
+        logger.warn("Password not provided")
         # Windows getpass does not accept unicode
         args.password = getpass.getpass()
 

--- a/commcare_export/cli.py
+++ b/commcare_export/cli.py
@@ -28,9 +28,10 @@ from commcare_export.misc import default_to_json
 from commcare_export.repeatable_iterator import RepeatableIterator
 from commcare_export.utils import get_checkpoint_manager
 from commcare_export.version import __version__
-from commcare_export import logger, get_error_logger
+from commcare_export import get_logger, get_error_logger
 
 EXIT_STATUS_ERROR = 1
+logger = get_logger(__file__)
 
 commcare_hq_aliases = {
     'local': 'http://localhost:8000',

--- a/commcare_export/cli.py
+++ b/commcare_export/cli.py
@@ -28,7 +28,7 @@ from commcare_export.misc import default_to_json
 from commcare_export.repeatable_iterator import RepeatableIterator
 from commcare_export.utils import get_checkpoint_manager
 from commcare_export.version import __version__
-from commcare_export import logger
+from commcare_export import logger, Logger
 
 EXIT_STATUS_ERROR = 1
 
@@ -165,7 +165,14 @@ CLI_ARGS = [
         "form.form..case, messaging-event.messages.[*] And you want to "
         "have a record exported even if the nested document does not "
         "exist or is empty.",
-    )
+    ),
+    Argument(
+        'no-logfile',
+        default=False,
+        help="Specify in order to prevent information being logged to the log file and"
+             " show all output in the console.",
+        action='store_true',
+    ),
 ]
 
 
@@ -177,6 +184,17 @@ def main(argv):
         arg.add_to_parser(parser)
 
     args = parser.parse_args(argv)
+
+    if not args.no_logfile:
+        exe_dir = os.path.dirname(sys.executable)
+        log_file = os.path.join(exe_dir, "commcare_export.log")
+        print(f"Printing logs to {log_file}")
+        logging.basicConfig(
+            filename=log_file,
+            format='%(asctime)s %(name)-12s %(levelname)-8s %(message)s',
+            filemode='w',
+        )
+        sys.stderr = Logger(logging.getLogger(), logging.ERROR)
 
     if args.verbose:
         logging.basicConfig(

--- a/commcare_export/cli.py
+++ b/commcare_export/cli.py
@@ -2,10 +2,9 @@ import argparse
 import getpass
 import io
 import json
-import logging
 import os.path
 import sys
-
+import logging
 import dateutil.parser
 import requests
 import sqlalchemy
@@ -29,10 +28,9 @@ from commcare_export.misc import default_to_json
 from commcare_export.repeatable_iterator import RepeatableIterator
 from commcare_export.utils import get_checkpoint_manager
 from commcare_export.version import __version__
+from commcare_export import logger
 
 EXIT_STATUS_ERROR = 1
-
-logger = logging.getLogger(__name__)
 
 commcare_hq_aliases = {
     'local': 'http://localhost:8000',
@@ -200,10 +198,14 @@ def main(argv):
         exit(0)
 
     if not args.project:
+        error_msg = "commcare-export: error: argument --project is required"
+        # output to log file through sys.stderr
         print(
-            'commcare-export: error: argument --project is required',
+            error_msg,
             file=sys.stderr
         )
+        # Output to console for debugging
+        print(error_msg)
         exit(1)
 
     if args.profile:
@@ -214,7 +216,12 @@ def main(argv):
         profile.start()
 
     try:
-        exit(main_with_args(args))
+        print("Running...")
+        try:
+            exit(main_with_args(args))
+        except Exception:
+            print("Error occurred! See log file for error.")
+            raise
     finally:
         if args.profile:
             profile.close()

--- a/commcare_export/cli.py
+++ b/commcare_export/cli.py
@@ -28,7 +28,7 @@ from commcare_export.misc import default_to_json
 from commcare_export.repeatable_iterator import RepeatableIterator
 from commcare_export.utils import get_checkpoint_manager
 from commcare_export.version import __version__
-from commcare_export import logger, Logger
+from commcare_export import logger, get_error_logger
 
 EXIT_STATUS_ERROR = 1
 
@@ -194,7 +194,7 @@ def main(argv):
             format='%(asctime)s %(name)-12s %(levelname)-8s %(message)s',
             filemode='w',
         )
-        sys.stderr = Logger(logging.getLogger(), logging.ERROR)
+        sys.stderr = get_error_logger()
 
     if args.verbose:
         logging.basicConfig(

--- a/commcare_export/commcare_hq_client.py
+++ b/commcare_export/commcare_hq_client.py
@@ -20,7 +20,7 @@ from requests.auth import AuthBase, HTTPDigestAuth
 
 import commcare_export
 from commcare_export.repeatable_iterator import RepeatableIterator
-from commcare_export import logger
+from commcare_export import get_logger
 
 AUTH_MODE_PASSWORD = 'password'
 AUTH_MODE_APIKEY = 'apikey'
@@ -28,6 +28,8 @@ AUTH_MODE_APIKEY = 'apikey'
 
 LATEST_KNOWN_VERSION = '0.5'
 RESOURCE_REPEAT_LIMIT = 10
+
+logger = get_logger(__file__)
 
 
 def on_wait(details):

--- a/commcare_export/commcare_hq_client.py
+++ b/commcare_export/commcare_hq_client.py
@@ -8,8 +8,6 @@ from __future__ import (
 )
 
 import copy
-import logging
-import time
 from collections import OrderedDict
 from math import ceil
 from urllib.parse import urlencode
@@ -20,19 +18,20 @@ from requests.auth import AuthBase, HTTPDigestAuth
 
 import commcare_export
 from commcare_export.repeatable_iterator import RepeatableIterator
-from datetime import datetime
+from commcare_export import logger
 
 AUTH_MODE_PASSWORD = 'password'
 AUTH_MODE_APIKEY = 'apikey'
 
-logger = logging.getLogger(__name__)
 
 LATEST_KNOWN_VERSION = '0.5'
 RESOURCE_REPEAT_LIMIT = 10
 
+
 def on_wait(details):
     time_to_wait = details["wait"]
     logger.warning(f"Rate limit reached. Waiting for {time_to_wait} seconds.")
+
 
 def on_backoff(details):
     _log_backoff(details, 'Waiting for retry.')

--- a/commcare_export/commcare_minilinq.py
+++ b/commcare_export/commcare_minilinq.py
@@ -5,7 +5,6 @@ To date, this is simply built-ins for querying the
 API directly.
 """
 import json
-import logging
 from enum import Enum
 from urllib.parse import parse_qs, urlparse
 from datetime import datetime
@@ -14,8 +13,7 @@ from dateutil.parser import ParserError, parse
 
 from commcare_export.env import CannotBind, CannotReplace, DictEnv
 from commcare_export.misc import unwrap
-
-logger = logging.getLogger(__name__)
+from commcare_export import logger
 
 SUPPORTED_RESOURCES = {
     'form',

--- a/commcare_export/commcare_minilinq.py
+++ b/commcare_export/commcare_minilinq.py
@@ -13,7 +13,9 @@ from dateutil.parser import ParserError, parse
 
 from commcare_export.env import CannotBind, CannotReplace, DictEnv
 from commcare_export.misc import unwrap
-from commcare_export import logger
+from commcare_export import get_logger
+
+logger = get_logger(__file__)
 
 SUPPORTED_RESOURCES = {
     'form',

--- a/commcare_export/location_info_provider.py
+++ b/commcare_export/location_info_provider.py
@@ -1,9 +1,7 @@
-import logging
 
 from commcare_export.commcare_minilinq import SimplePaginator
 from commcare_export.misc import unwrap_val
-
-logger = logging.getLogger(__name__)
+from commcare_export import logger
 
 # LocationInfoProvider uses the /location_type/ endpoint of the API to
 # retrieve location type data, stores that information in a dictionary

--- a/commcare_export/location_info_provider.py
+++ b/commcare_export/location_info_provider.py
@@ -1,7 +1,9 @@
 
 from commcare_export.commcare_minilinq import SimplePaginator
 from commcare_export.misc import unwrap_val
-from commcare_export import logger
+from commcare_export import get_logger
+
+logger = get_logger(__file__)
 
 # LocationInfoProvider uses the /location_type/ endpoint of the API to
 # retrieve location type data, stores that information in a dictionary

--- a/commcare_export/minilinq.py
+++ b/commcare_export/minilinq.py
@@ -6,7 +6,9 @@ from commcare_export.env import Env
 from commcare_export.misc import unwrap, unwrap_val
 from commcare_export.repeatable_iterator import RepeatableIterator
 from commcare_export.specs import TableSpec
-from commcare_export import logger
+from commcare_export import get_logger
+
+logger = get_logger(__file__)
 
 
 class MiniLinq(object):

--- a/commcare_export/minilinq.py
+++ b/commcare_export/minilinq.py
@@ -1,4 +1,3 @@
-import logging
 from typing import Any, Dict
 from typing import List as ListType
 from typing import Optional
@@ -7,8 +6,7 @@ from commcare_export.env import Env
 from commcare_export.misc import unwrap, unwrap_val
 from commcare_export.repeatable_iterator import RepeatableIterator
 from commcare_export.specs import TableSpec
-
-logger = logging.getLogger(__name__)
+from commcare_export import logger
 
 
 class MiniLinq(object):

--- a/commcare_export/utils_cli.py
+++ b/commcare_export/utils_cli.py
@@ -8,8 +8,6 @@ from commcare_export.utils import confirm, get_checkpoint_manager, print_runs
 
 EXIT_STATUS_ERROR = 1
 
-logger = logging.getLogger(__name__)
-
 
 class BaseCommand(object):
     slug = None

--- a/commcare_export/writers.py
+++ b/commcare_export/writers.py
@@ -1,7 +1,6 @@
 import csv
 import datetime
 import io
-import logging
 import zipfile
 from itertools import zip_longest
 
@@ -12,8 +11,7 @@ from alembic.migration import MigrationContext
 from alembic.operations import Operations
 from commcare_export.data_types import UnknownDataType, get_sqlalchemy_type
 from commcare_export.specs import TableSpec
-
-logger = logging.getLogger(__name__)
+from commcare_export import logger
 
 MAX_COLUMN_SIZE = 2000
 

--- a/commcare_export/writers.py
+++ b/commcare_export/writers.py
@@ -11,8 +11,9 @@ from alembic.migration import MigrationContext
 from alembic.operations import Operations
 from commcare_export.data_types import UnknownDataType, get_sqlalchemy_type
 from commcare_export.specs import TableSpec
-from commcare_export import logger
+from commcare_export import get_logger
 
+logger = get_logger(__file__)
 MAX_COLUMN_SIZE = 2000
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -351,6 +351,7 @@ def _pull_data(writer, checkpoint_manager, query, since, until, batch_size=10):
         batch_size=batch_size,
         since=since,
         until=until,
+        no_logfile=True,
     )
 
     # set this so that it gets written to the checkpoints

--- a/tests/test_commcare_export.py
+++ b/tests/test_commcare_export.py
@@ -1,0 +1,29 @@
+import os
+from commcare_export import logger_name_from_filepath, repo_root
+
+
+class TestLoggerNameFromFilePath:
+
+    @staticmethod
+    def _file_path(rel_path):
+        return os.path.join(repo_root, rel_path)
+
+    def test_file_in_root(self):
+        path = self._file_path("file.py")
+        assert logger_name_from_filepath(path) == 'file'
+
+    def test_file_in_subdirectory(self):
+        path = self._file_path("subdir/file.py")
+        assert logger_name_from_filepath(path) == 'subdir.file'
+
+    def test_file_in_deeper_subdirectory(self):
+        path = self._file_path("subdir/another_sub/file.py")
+        assert logger_name_from_filepath(path) == 'subdir.another_sub.file'
+
+    def test_file_contains_py(self):
+        path = self._file_path("subdir/pytest.py")
+        assert logger_name_from_filepath(path) == 'subdir.pytest'
+
+    def test_file_dir_contains_periods(self):
+        path = self._file_path("sub.dir/pytest.py")
+        assert logger_name_from_filepath(path) == 'sub.dir.pytest'

--- a/tests/test_commcare_export.py
+++ b/tests/test_commcare_export.py
@@ -27,3 +27,7 @@ class TestLoggerNameFromFilePath:
     def test_file_dir_contains_periods(self):
         path = self._file_path("sub.dir/pytest.py")
         assert logger_name_from_filepath(path) == 'sub.dir.pytest'
+
+    def test_random_file_name(self):
+        path = self._file_path("pyppy.excel_query.py")
+        assert logger_name_from_filepath(path) == 'pyppy.excel_query'


### PR DESCRIPTION
[Ticket](https://dimagi.atlassian.net/browse/SC-3373)

The feature in this PR will become more important when [this ticket](https://dimagi.atlassian.net/browse/SC-3351) is implemented, i.e. when we're able to create executable files from the DET.

What this PR does is the following:
- Add a `Logger` class which allows stderr to log to same log file than other logs.
- Tunnel all `stderr` messages through to the logger so it will show up in the logs and not in the terminal, unless the user specifies a new flag, `no-logfile`, which will show all output in the terminal and not in the log file.