### PR TITLE
Improve DET errors

### DIFF
--- a/commcare_export/cli.py
+++ b/commcare_export/cli.py
@@ -186,6 +186,12 @@ def main(argv):
 
     args = parser.parse_args(argv)
 
+    if args.output_format and args.output:
+        errors = []
+        errors.extend(validate_output_filename(args.output_format, args.output))
+        if errors:
+            raise Exception(f"Could not proceed. Following issues were found: {', '.join(errors)}.")
+
     if not args.no_logfile:
         exe_dir = os.path.dirname(sys.executable)
         log_file = os.path.join(exe_dir, "commcare_export.log")
@@ -252,6 +258,23 @@ def main(argv):
             stats.strip_dirs()
             stats.sort_stats('cumulative', 'calls')
             stats.print_stats(100)
+
+
+def validate_output_filename(output_format, output_filename):
+    """
+    Validate file extensions for csv, xls and xlsx output formats.
+    Ensure extension unless using sql output_format.
+    """
+    errors = []
+    if output_format == 'csv' and not output_filename.endswith('.zip'):
+        errors.append("For output format as csv, output file name should have extension zip")
+    elif output_format == 'xls' and not output_filename.endswith('.xls'):
+        errors.append("For output format as xls, output file name should have extension xls")
+    elif output_format == 'xlsx' and not output_filename.endswith('.xlsx'):
+        errors.append("For output format as xlsx, output file name should have extension xlsx")
+    elif output_format != 'sql' and "." not in output_filename:
+        errors.append("Missing extension in output file name")
+    return errors
 
 
 def _get_query(args, writer, column_enforcer=None):

--- a/commcare_export/commcare_hq_client.py
+++ b/commcare_export/commcare_hq_client.py
@@ -164,7 +164,8 @@ class CommCareHqClient(object):
                             logger.error(
                                 f"#{e}. Please ensure that your CommCare HQ credentials are correct and auth-mode "
                                 f"is passed as 'apikey' if using API Key to authenticate. Also, verify that your "
-                                f"account has the necessary permissions to use commcare-export."
+                                f"account has access to the project and the necessary permissions to use "
+                                f"commcare-export."
                             )
                         else:
                             logger.error(str(e))

--- a/tests/test_commcare_hq_client.py
+++ b/tests/test_commcare_hq_client.py
@@ -329,8 +329,8 @@ class TestCommCareHqClient(unittest.TestCase):
         logger_mock.error.assert_called_once_with(
             "#401 Client Error: None for url: None. "
             "Please ensure that your CommCare HQ credentials are correct and auth-mode is passed as 'apikey' "
-            "if using API Key to authenticate. Also, verify that your account has the necessary permissions "
-            "to use commcare-export.")
+            "if using API Key to authenticate. Also, verify that your account has access to the project "
+            "and the necessary permissions to use commcare-export.")
 
     @patch('commcare_export.commcare_hq_client.logger')
     @patch("commcare_export.commcare_hq_client.CommCareHqClient.session")


### PR DESCRIPTION
https://dimagi.atlassian.net/browse/SC-3407

Improving on some validations around expected output filename for the passed in output format.

1. Taking hints from how the [writer](https://github.com/dimagi/commcare-export/blob/a4fcf3fb19021c0a4cb33d58dd44a9df346c4d7a/commcare_export/cli.py#L339) is picked for a format, validated the extensions for csv, xls and xlsx. CSV files are actually stored in a zip file. Earlier using csv extension for csv format only gave a [warning](https://github.com/dimagi/commcare-export/blob/a4fcf3fb19021c0a4cb33d58dd44a9df346c4d7a/commcare_export/cli.py#L346-L352), we are now making it mandatory.
2. Additionally, for other non-sql output (json/markdown), validated that an extension is present in output filename, if used.

This will cause errors if users accidentally use the incorrect filenames for passed output format and let users know the fix for the same.

Along with this, a minor change to the error message related to authentication, to let user know that they should also ensure they have access to the project space.

Tested locally.

Also requested for QA here, https://dimagi.atlassian.net/browse/QA-6333