### PR TITLE
Add simple script commcare-export-multi

### DIFF
--- a/commcare-export-multi
+++ b/commcare-export-multi
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# Usage:
+#
+#   PROJECTS="project1 project2 project3" commcare-export-multi [all the same args you'd use for commcare-export]
+#
+
+for PROJECT in ${PROJECTS}
+do
+  echo "commcare-export $@ --project ${PROJECT}"
+  commcare-export "$@" --project ${PROJECT}
+done


### PR DESCRIPTION
I realize we could try and embed this directly in the python code itself and the `--project` argument, but adding this script was extremely simple and I wanted to have something workable quickly.